### PR TITLE
chore: update Claude Code plugin settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,23 @@
     "backend@passionfactory": true,
     "typescript-lsp@language-server-please": true,
     "eslint-lsp@language-server-please": true,
-    "gatekeeper@pleaseai": true
+    "gatekeeper@pleaseai": true,
+    "mcp-dev@pleaseai": true,
+    "plugin-dev@claude-plugins-official": true
+  },
+  "extraKnownMarketplaces": {
+    "anthropic-agent-skills": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/skills"
+      }
+    },
+    "pleaseai": {
+      "source": {
+        "source": "github",
+        "repo": "pleaseai/claude-code-plugins"
+      }
+    }
   },
   "language": "english"
 }


### PR DESCRIPTION
## Summary
- Add `mcp-dev` and `plugin-dev` plugins to allowed plugins
- Configure extra known marketplaces (`anthropic-agent-skills`, `pleaseai`)

## Test plan
- [x] No code changes, settings-only update
- [x] Verify `.claude/settings.json` is valid JSON

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable dev plugin workflows in Claude Code by allowing mcp-dev and plugin-dev. Also register Anthropic Agent Skills and PleaseAI marketplaces for easier discovery.

- **New Features**
  - Allow mcp-dev@pleaseai and plugin-dev@claude-plugins-official.
  - Add marketplaces: anthropic-agent-skills (anthropics/skills) and pleaseai (pleaseai/claude-code-plugins).

<sup>Written for commit 8a9d90f8b2179626280c0ad37c17676a1c9ee943. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

