### PR TITLE
docs: add LLM model configuration to CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The `-m, --model` option uses `provider/model` format. If the model is omitted, 
 |----------|--------|---------------|-----------------|
 | `openai` | `openai/gpt-5.2` | `gpt-4o` | `OPENAI_API_KEY` |
 | `anthropic` | `anthropic/claude-haiku-4.5` | `claude-sonnet-4.5` | `ANTHROPIC_API_KEY` |
-| `google` | `google/gemini-3-pro-preview` | `gemini-3-flash-preview` | `GOOGLE_GENERATIVE_AI_API_KEY` |
+| `google` | `google/gemini-3-pro-preview` | `gemini-3-flash-preview` | `GOOGLE_API_KEY` |
 | `claude-code` | `claude-code/haiku` | `sonnet` | Not required (uses subscription) |
 
 ## Project Structure


### PR DESCRIPTION
## Summary

Added comprehensive documentation for LLM model configuration options in the CLI Usage section of README.md.

## Changes

- Added `-m, --model` option examples for all supported providers (google, openai, anthropic, claude-code)
- Added `--no-llm` heuristic-only mode example
- Created Model Configuration table showing provider format, default models, and API key environment variables
- Added evolve command model usage example

## Benefits

- Improves discoverability of LLM provider options
- Makes it easier for users to understand model configuration syntax
- Documents API key requirements for each provider
- Shows claude-code provider option that doesn't require API keys

## Test Plan

- [x] Verified markdown formatting renders correctly
- [x] Confirmed all provider examples follow correct syntax
- [x] Validated table formatting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added clear CLI docs for configuring LLM models, including provider-specific -m/--model examples (Google, OpenAI, Anthropic, Claude Code), --no-llm heuristic mode, evolve usage with -m, and a model configuration table with defaults and API key env vars. Updated the Google provider env var to GOOGLE_API_KEY to match the implementation.

<sup>Written for commit e6b219017f6ed06a2d4629f641bd4ff9a71dd674. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

