### PR TITLE
chore: bump packageManager to bun@1.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clean": "rm -rf dist",
     "prepublishOnly": "bun run build"
   },
-  "packageManager": "bun@1.3.7",
+  "packageManager": "bun@1.3.9",
   "dependencies": {
     "tree-sitter": "^0.21.1",
     "tree-sitter-go": "0.21.2",


### PR DESCRIPTION
## Summary

- Update `packageManager` field in `package.json` from `bun@1.3.7` to `bun@1.3.9`

## Changes

- Bump Bun package manager version from 1.3.7 to 1.3.9

## Test Plan

- [ ] Verify `bun install` works correctly with the updated version
- [ ] Confirm CI passes with bun@1.3.9

## Notes

- Submodule dirty states (`tests/fixtures/nextjs`, `tests/fixtures/superjson`) are local-only and not included in this PR
- Untracked `packages/cli/src/.please/` directory is also excluded

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update packageManager in package.json from bun@1.3.7 to bun@1.3.9 to use the latest stable Bun and keep local and CI installs consistent.

<sup>Written for commit 44be8f982f9d9f460a40944f78d2b86de3b447e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

