### PR TITLE
ci: bump node-version from 22 to 24 in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: bun install --frozen-lockfile
       - run: bunx turbo run build


### PR DESCRIPTION
## Summary

- Update the Node.js version in the `release-please` publish job from `22` to `24`
- Node 24 is the current Active LTS release and aligns with the project's use of Bun 1.3.9+

## Changes

- `.github/workflows/release-please.yml`: `node-version: '22'` → `node-version: '24'`

## Test Plan

- [ ] Verify the release workflow runs successfully on merge to `main`
- [ ] Confirm npm publish step completes without version compatibility issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the release workflow to use Node.js 24 instead of 22. This aligns with Active LTS and our Bun 1.3.9+ setup, ensuring compatibility for build and npm publish steps.

<sup>Written for commit dc4235f22279471387ec65502719988a59216749. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

