### PR TITLE
refactor: move semantic cache from .please/cache to .rpg/cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,16 +35,18 @@ coverage/
 
 # RPG local data
 .rpg/local/
+.rpg/cache/
 
 # Bun
 bun.lockb
 /.claude/settings.local.json
 
 # Please AI session state
-.please/cache/
 .please/memory/
 .please/tasklist.json
 /rpg.json
 
 # Turborepo
 .turbo
+
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ RPG uses a two-tier architecture for data management:
 .rpg/
   graph.json          # Canonical RPG (git committed, CI-managed)
   config.json         # Encode/sync settings (git committed)
+  cache/              # Semantic cache (gitignored)
+    semantic-cache.db # LLM response cache (SQLite, WAL mode)
   local/              # Local-only data (gitignored)
     graph.json        # Local evolved RPG copy
     vectors/          # Local vector embeddings (LocalVectorStore, JSON-based)

--- a/packages/encoder/src/cache.ts
+++ b/packages/encoder/src/cache.ts
@@ -51,7 +51,7 @@ export class SemanticCache {
 
   constructor(options: CacheOptions = {}) {
     this.options = {
-      cacheDir: options.cacheDir ?? '.please/cache',
+      cacheDir: options.cacheDir ?? '.rpg/cache',
       ttl: options.ttl ?? DEFAULT_TTL,
       enabled: options.enabled ?? true,
     }

--- a/packages/encoder/src/encoder.ts
+++ b/packages/encoder/src/encoder.ts
@@ -495,7 +495,7 @@ export class RPGEncoder {
     // Initialize semantic extractor and cache
     this.semanticExtractor = new SemanticExtractor(this.options.semantic)
     this.cache = new SemanticCache({
-      cacheDir: path.join(this.repoPath, '.please', 'cache'),
+      cacheDir: path.join(this.repoPath, '.rpg', 'cache'),
       ...this.options.cache,
     })
 


### PR DESCRIPTION
## Summary

- Move semantic cache directory from `.please/cache` to `.rpg/cache` to consolidate all RPG-related local data under the `.rpg/` directory
- Update `.gitignore` to reflect the new cache location
- Update `CLAUDE.md` documentation to include `cache/` in the `.rpg/` directory structure

## Changes

- `packages/encoder/src/cache.ts`: Change default `cacheDir` from `.please/cache` to `.rpg/cache`
- `packages/encoder/src/encoder.ts`: Update `cacheDir` path reference from `.please/cache` to `.rpg/cache`
- `.gitignore`: Replace `.please/cache/` and `**/.please/cache/` ignore rules with `.rpg/cache/`
- `CLAUDE.md`: Add `cache/` entry to the `.rpg/` directory structure documentation

## Test Plan

- [ ] Verify encoder runs and creates cache under `.rpg/cache/` instead of `.please/cache/`
- [ ] Confirm `.rpg/cache/` is properly gitignored
- [ ] Verify existing tests pass with the new cache path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the semantic cache from .please/cache to .rpg/cache to centralize RPG data and align with existing ignore rules. Updated encoder defaults, .gitignore, and docs to use the new path.

- **Migration**
  - If needed, move existing cache from .please/cache to .rpg/cache.
  - No code changes required; encoder now defaults to .rpg/cache.

<sup>Written for commit 5dda7f332ff8e518cb17995a4feb99e8cadf3062. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

