### PR TITLE
ci: add explicit Gemini 3 Flash model flag to rpg-encode workflow

### DIFF
--- a/.github/workflows/rpg-encode.yml
+++ b/.github/workflows/rpg-encode.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Install RPG
         run: bun install -g @pleaseai/rpg
 
+      - name: Restore semantic cache
+        uses: actions/cache@v4
+        with:
+          path: .rpg/cache/semantic-cache.db*
+          key: semantic-cache-${{ github.sha }}
+          restore-keys: semantic-cache-
+
       - name: Encode or evolve RPG
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}


### PR DESCRIPTION
## Summary

- Add `-m google/gemini-3-flash-preview` flag to all `rpg encode` and `rpg evolve` commands in the CI workflow
- Ensures the Gemini 3 Flash model is explicitly selected for semantic extraction instead of relying on the default
- Applies to full encode, no-stamp fallback encode, incremental evolve, and evolve-failure fallback paths

## Test Plan

- [ ] Verify CI workflow runs successfully on next push to main
- [ ] Confirm `rpg encode` uses `google/gemini-3-flash-preview` model in workflow logs
- [ ] Confirm `rpg evolve` uses `google/gemini-3-flash-preview` model in workflow logs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly set the google/gemini-3-flash-preview model for all rpg encode and rpg evolve steps, and restore the semantic cache to reuse LLM outputs. This ensures consistent semantic extraction across full, incremental, and fallback runs and reduces API cost and runtime.

<sup>Written for commit 5d9145feb58a455b1ef273d60cb7f2f9f41c7c86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

