### PR TITLE
ci(workflow): add 10-minute timeout to rpg-encode job

### DIFF
--- a/.github/workflows/rpg-encode.yml
+++ b/.github/workflows/rpg-encode.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   encode:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Add `timeout-minutes: 10` to the `encode` job in `.github/workflows/rpg-encode.yml`
- Prevents the workflow from running indefinitely in case of hangs or unexpected failures during encoding

## Test Plan

- [ ] Verify the workflow runs successfully within the 10-minute window
- [ ] Confirm the job is cancelled automatically if it exceeds 10 minutes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a 10-minute timeout to the rpg-encode GitHub Actions job to prevent indefinite runs if encoding hangs. The job now auto-cancels when it exceeds 10 minutes.

<sup>Written for commit 01abe77340a8d9d83a2c017a1a899de296bedb0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

