### PR TITLE
chore: add .worktreeinclude with RPG-relevant entries

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -10,3 +10,6 @@
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# ESLint cache
+.eslintcache


### PR DESCRIPTION
## Summary

- Add `.worktreeinclude` file to define RPG-relevant paths for git worktree operations
- Includes entries for Turbo cache (`.turbo/`), TypeScript build info (`*.tsbuildinfo`), local environment overrides (`.env.local`, `.env.*.local`), and Claude Code local settings (`.claude/settings.local.json`)
- Comments are written in English per project conventions (translated from Korean)

## Changes

- New file: `.worktreeinclude` with 12 lines of RPG-relevant include entries

## Test Plan

- [ ] Verify `.worktreeinclude` is present in the repository root
- [ ] Confirm submodule dirty markers (`tests/fixtures/nextjs`, `tests/fixtures/superjson`) are NOT included in this PR
- [ ] Check that `.please/cache/` and `packages/cli/src/.please/` untracked directories are NOT included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add .worktreeinclude to include Turbo cache, TS build info, .env.local overrides, Claude Code settings, and ESLint cache in worktrees, keeping builds/lint fast and local configs intact.

<sup>Written for commit e8177dad8f4354a7b69e473265719183bfc7c178. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

