### PR TITLE
chore: bump bun package manager to 1.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf packages/soop/dist"
   },
-  "packageManager": "bun@1.3.9",
+  "packageManager": "bun@1.3.10",
   "dependencies": {
     "tree-sitter": "0.25.0",
     "tree-sitter-c": "0.24.1",


### PR DESCRIPTION
## Summary

- Update `packageManager` field in `package.json` from `bun@1.3.9` to `bun@1.3.10`

## Test Plan

- [ ] Verify CI passes with the updated bun version
- [ ] Confirm `bun install` works correctly on the updated version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates package.json to use bun@1.3.10 (from 1.3.9) to keep local installs and CI on the latest patch version.

<sup>Written for commit bf9957bd7b77f9f83d9125509b0cd25d9e930209. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

