### PR TITLE
fix(build): disable bytecode for Windows targets to avoid Bun crash

### DIFF
--- a/scripts/generate-packages.ts
+++ b/scripts/generate-packages.ts
@@ -110,7 +110,7 @@ async function buildBinary(
     outfile,
     target: target as Parameters<typeof Bun.build>[0]['target'],
     compile: true,
-    bytecode: !target.includes('windows'), // https://github.com/oven-sh/bun/issues/18416
+    bytecode: target.split('-')[1] !== 'windows', // https://github.com/oven-sh/bun/issues/18416
     minify: true,
     // Embed all @pleaseai/* workspace packages; exclude heavy native/optional deps
     external: [


### PR DESCRIPTION
## Summary

Bun crashes with an internal assertion failure when `--bytecode` and `--compile` are combined for Windows cross-compilation targets.

```
panic: Internal assertion failure: total_insertions (1) != output_files.items.len (2)
```

This is a confirmed upstream bug ([oven-sh/bun#18416](https://github.com/oven-sh/bun/issues/18416)).

## Changes

- `scripts/generate-packages.ts`: make `bytecode` conditional — disabled for Windows targets, enabled for all others

## Impact

- **Windows**: bytecode disabled → slightly slower cold start, but builds succeed
- **Linux / macOS**: unchanged — bytecode still enabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Bun bytecode for Windows targets to avoid a cross-compilation crash, using structured parsing of the Bun target to detect Windows. Windows builds now succeed; Linux and macOS are unchanged.

<sup>Written for commit 8738f4dcdd7511b167e8b5e46f9207162045287a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

