### PR TITLE
ci: skip npm publish if package version already exists

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -145,8 +145,14 @@ jobs:
         if: ${{ github.event.inputs.dry_run != 'true' }}
         run: |
           for dir in npm/soop-*/; do
-            echo "Publishing $dir..."
-            (cd "$dir" && npm publish --access public --provenance)
+            name=$(cat "$dir/package.json" | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])")
+            version=$(cat "$dir/package.json" | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])")
+            if npm view "${name}@${version}" version 2>/dev/null | grep -q "${version}"; then
+              echo "Skipping $name@$version (already published)"
+            else
+              echo "Publishing $dir..."
+              (cd "$dir" && npm publish --access public --provenance)
+            fi
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -154,7 +160,14 @@ jobs:
       # Publish main @pleaseai/soop package (OIDC trusted publishing — no token needed)
       - name: Publish main package
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        run: cd packages/soop && npm publish --access public --provenance
+        run: |
+          name=$(cat packages/soop/package.json | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])")
+          version=$(cat packages/soop/package.json | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])")
+          if npm view "${name}@${version}" version 2>/dev/null | grep -q "${version}"; then
+            echo "Skipping ${name}@${version} (already published)"
+          else
+            cd packages/soop && npm publish --access public --provenance
+          fi
 
       # Dry run — show what would be published
       - name: Dry run summary


### PR DESCRIPTION
## Summary

- Add idempotency checks to both npm publish steps in the release workflow
- Before publishing, check if the package version already exists on the npm registry using `npm view`
- If already published, skip with an informational message instead of failing

## Motivation

Re-running the release workflow (e.g., after a partial failure or manual trigger) would previously fail with a 403 error when attempting to publish an already-existing version. This change makes the workflow safe to re-run without side effects.

## Changes

- `ci(release): skip soop-* packages if version already on registry` — loops over `npm/soop-*/` and checks before publishing
- `ci(release): skip main @pleaseai/soop package if version already on registry` — same check for the main package

## Test Plan

- [ ] Verify dry-run workflow step is unaffected (guarded by `dry_run != 'true'`)
- [ ] Confirm publish step skips gracefully when package version exists on npm
- [ ] Confirm publish step proceeds normally when package version is new

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the release workflow idempotent by skipping npm publish when the target version already exists. Each soop-* package and @pleaseai/soop now checks npm view name@version and logs a skip instead of failing; dry-run behavior is unchanged.

<sup>Written for commit d2f46677549bb849329c46403ccf2a7454e09011. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

