### PR TITLE
ci: skip lint/test/typecheck for release-please branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip for release-please branches
+        if: startsWith(github.head_ref, 'release-please--')
+        run: echo "Release-please branch — skipping typecheck" && exit 0
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
@@ -22,6 +25,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip for release-please branches
+        if: startsWith(github.head_ref, 'release-please--')
+        run: echo "Release-please branch — skipping lint" && exit 0
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
@@ -30,6 +36,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip for release-please branches
+        if: startsWith(github.head_ref, 'release-please--')
+        run: echo "Release-please branch — skipping tests" && exit 0
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
@@ -47,6 +56,9 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip for release-please branches
+        if: startsWith(github.head_ref, 'release-please--')
+        run: echo "Release-please branch — skipping integration tests" && exit 0
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary

- Add early-exit steps to `typecheck`, `lint`, `test`, and `integration-test` CI jobs
- Jobs detect `release-please--` branches via `startsWith(github.head_ref, 'release-please--')` condition and exit immediately with `exit 0`
- These branches contain only version bumps (CHANGELOG, package.json), so re-running expensive checks is unnecessary

## Why exit 0?

The `exit 0` pattern ensures required status checks still report as **success** rather than skipped, allowing release-please PRs to merge without branch protection rule issues.

## Test plan

- [ ] Verify existing CI jobs still run normally on non-release-please branches
- [ ] Verify release-please PRs show all jobs as passing (via early exit)
- [ ] Confirm no regressions on main branch pushes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip typecheck, lint, test, and integration-test jobs on release-please branches to save CI time. These jobs exit 0 when head_ref starts with "release-please--", keeping required checks green while avoiding redundant runs on version-bump PRs.

<sup>Written for commit 8df926a33dd47c96048cae76ede5f852c3328381. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

