### PR TITLE
ci: use GITHUB_OUTPUT flag to properly skip steps on release-please b…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,38 +14,63 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip for release-please branches
-        if: startsWith(github.head_ref, 'release-please--')
-        run: echo "Release-please branch — skipping typecheck" && exit 0
+      - name: Check if release-please branch
+        id: branch-check
+        run: |
+          if [[ "${{ github.head_ref }}" == release-please--* ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Release-please branch — skipping typecheck"
+          fi
       - uses: actions/checkout@v6
+        if: steps.branch-check.outputs.skip != 'true'
       - uses: oven-sh/setup-bun@v2
+        if: steps.branch-check.outputs.skip != 'true'
       - run: bun install --frozen-lockfile
+        if: steps.branch-check.outputs.skip != 'true'
       - run: bunx turbo run typecheck
+        if: steps.branch-check.outputs.skip != 'true'
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip for release-please branches
-        if: startsWith(github.head_ref, 'release-please--')
-        run: echo "Release-please branch — skipping lint" && exit 0
+      - name: Check if release-please branch
+        id: branch-check
+        run: |
+          if [[ "${{ github.head_ref }}" == release-please--* ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Release-please branch — skipping lint"
+          fi
       - uses: actions/checkout@v6
+        if: steps.branch-check.outputs.skip != 'true'
       - uses: oven-sh/setup-bun@v2
+        if: steps.branch-check.outputs.skip != 'true'
       - run: bun install --frozen-lockfile
+        if: steps.branch-check.outputs.skip != 'true'
       - run: bunx turbo run lint
+        if: steps.branch-check.outputs.skip != 'true'
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip for release-please branches
-        if: startsWith(github.head_ref, 'release-please--')
-        run: echo "Release-please branch — skipping tests" && exit 0
+      - name: Check if release-please branch
+        id: branch-check
+        run: |
+          if [[ "${{ github.head_ref }}" == release-please--* ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Release-please branch — skipping tests"
+          fi
       - uses: actions/checkout@v6
+        if: steps.branch-check.outputs.skip != 'true'
         with:
           fetch-depth: 2
       - uses: oven-sh/setup-bun@v2
+        if: steps.branch-check.outputs.skip != 'true'
       - run: bun install --frozen-lockfile
+        if: steps.branch-check.outputs.skip != 'true'
       - run: bunx turbo run test:unit -- --coverage --coverage.reportsDirectory=./coverage/unit
+        if: steps.branch-check.outputs.skip != 'true'
       - uses: codecov/codecov-action@v5
+        if: steps.branch-check.outputs.skip != 'true'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: pleaseai/soop
@@ -56,17 +81,26 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip for release-please branches
-        if: startsWith(github.head_ref, 'release-please--')
-        run: echo "Release-please branch — skipping integration tests" && exit 0
+      - name: Check if release-please branch
+        id: branch-check
+        run: |
+          if [[ "${{ github.head_ref }}" == release-please--* ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Release-please branch — skipping integration tests"
+          fi
       - uses: actions/checkout@v6
+        if: steps.branch-check.outputs.skip != 'true'
         with:
           fetch-depth: 0
           submodules: true
       - uses: oven-sh/setup-bun@v2
+        if: steps.branch-check.outputs.skip != 'true'
       - run: bun install --frozen-lockfile
+        if: steps.branch-check.outputs.skip != 'true'
       - run: bunx turbo run test:integration -- --coverage --coverage.reportsDirectory=./coverage/integration
+        if: steps.branch-check.outputs.skip != 'true'
       - uses: codecov/codecov-action@v5
+        if: steps.branch-check.outputs.skip != 'true'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: pleaseai/soop


### PR DESCRIPTION
…ranches

The previous approach used `exit 0` which only exits the shell for that step but does not prevent subsequent steps from running. The new approach sets `skip=true` via GITHUB_OUTPUT in the first step, and all subsequent steps check `if: steps.branch-check.outputs.skip != 'true'` to correctly skip execution on release-please branches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI skipping for release-please branches by using GITHUB_OUTPUT to gate subsequent steps. This stops typecheck, lint, and tests from running on release-please branches.

- **Bug Fixes**
  - Add a branch-check step that sets skip=true via GITHUB_OUTPUT when head_ref starts with release-please--.
  - Guard all following steps with if: steps.branch-check.outputs.skip != 'true'.
  - Applied to typecheck, lint, test, and integration-test jobs.

<sup>Written for commit d0e5c69f5a1bd12a778b2c63982709a6cc64e690. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

