### PR TITLE
fix: add group-pull-request-title-pattern to prevent release-please abort

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
-  "group-pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+  "group-pull-request-title-pattern": "chore: release ${component} ${version}",
   "packages": {
     "packages/soop": {
       "package-name": "@pleaseai/soop",


### PR DESCRIPTION
## Summary

- Add `group-pull-request-title-pattern` to `release-please-config.json` to fix the "untagged, merged release PRs" abort
- Manually created `v0.1.14` GitHub release (pointing to `8d32f43`) and updated PR #140 label to `autorelease: tagged`

## Root Cause

The `node-workspace` plugin creates grouped PRs titled `"chore: release main"`, but release-please couldn't parse the component/version from this title. When only a subset of packages need releases (not all 9), this mismatch caused the abort.

See: https://github.com/googleapis/release-please/issues/1946

## Fix

Added `group-pull-request-title-pattern` config key so release-please knows the exact title format used for grouped PRs:

```json
"group-pull-request-title-pattern": "chore${scope}: release${component} ${version}"
```

## Test plan

- [x] `v0.1.14` GitHub release created manually at commit `8d32f43`
- [x] PR #140 label changed from `autorelease: pending` to `autorelease: tagged`
- [ ] Re-run `release-please.yml` workflow to verify it no longer aborts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added group-pull-request-title-pattern to release-please so it can parse grouped PR titles and stop aborting with "untagged, merged release PRs." Corrected the pattern to the documented default to avoid invalid "choremain:" titles.

- **Bug Fixes**
  - Use "chore: release ${component} ${version}" so release-please extracts component and version from grouped PRs.

<sup>Written for commit f5eee5bbbbc3606d2a1ea26267119918ed3ba1fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

