### PR TITLE
docs: Fix SonarCloud badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A unified framework for repository understanding and generation based on the Repository Planning Graph (RPG) representation.
 
 [![codecov](https://codecov.io/gh/pleaseai/soop/graph/badge.svg?token=PfprF4qUBw)](https://codecov.io/gh/pleaseai/soop)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_soop&metric=alert_status&token=689e64c38ea80939aaaa4089f723cfc1f879d9c1)](https://sonarcloud.io/summary/new_code?id=pleaseai_soop)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_soop&metric=security_rating&token=689e64c38ea80939aaaa4089f723cfc1f879d9c1)](https://sonarcloud.io/summary/new_code?id=pleaseai_soop)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_soop&metric=vulnerabilities&token=689e64c38ea80939aaaa4089f723cfc1f879d9c1)](https://sonarcloud.io/summary/new_code?id=pleaseai_soop)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_soop&metric=bugs&token=689e64c38ea80939aaaa4089f723cfc1f879d9c1)](https://sonarcloud.io/summary/new_code?id=pleaseai_soop)


### PR DESCRIPTION
Updated SonarCloud badges to reflect the correct project name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated README SonarCloud badges to use the correct project key (pleaseai_soop) and added a Quality Gate Status badge. Badges now show accurate Security, Vulnerabilities, and Bugs, and link to the correct summary page.

<sup>Written for commit 35a44cd8ae9236514d2700e2616b3a6f4ea0c40e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

