### PR TITLE
chore: update Claude plugin registry to use code-intelligence source

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "enabledPlugins": {
     "claude-md-management@claude-plugins-official": true,
     "dev-tools@passionfactory": true,
@@ -26,17 +29,16 @@
       "source": {
         "source": "github",
         "repo": "pleaseai/claude-code-plugins"
-      }
+      },
+      "autoUpdate": true
     },
     "code-intelligence": {
       "source": {
         "source": "github",
         "repo": "chatbot-pf/code-intelligence"
-      }
+      },
+      "autoUpdate": true
     }
   },
-  "language": "english",
-  "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
-  }
+  "language": "english"
 }


### PR DESCRIPTION
## Summary

- Migrate `typescript-lsp` and `eslint-lsp` plugins from the `language-server-please` registry to the new `code-intelligence` registry
- Add `code-intelligence` plugin registry entry sourced from `chatbot-pf/code-intelligence` on GitHub
- Add `engineering-standards` and `tidy-first` plugins from the `passionfactory` registry

## Changes

- `.claude/settings.json`: Update plugin source names and add new registry entry

## Test Plan

- [ ] Verify Claude Code loads plugins correctly from the updated registry sources
- [ ] Confirm `typescript-lsp` and `eslint-lsp` resolve via `code-intelligence` registry
- [ ] Confirm `engineering-standards` and `tidy-first` plugins load from `passionfactory`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Claude Code plugin sources to the new code-intelligence registry and enable auto-update for key registries. Also add two Passionfactory plugins and turn on experimental agent teams.

- **Dependencies**
  - Added code-intelligence registry (github: chatbot-pf/code-intelligence) with auto-update.
  - Moved typescript-lsp and eslint-lsp to code-intelligence.
  - Enabled engineering-standards and tidy-first from passionfactory.
  - Enabled auto-update for claude-md-management.
  - Set CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1.

<sup>Written for commit aa7adf20fe0b1adcab773453cade43e1b4e0e838. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

