### PR TITLE
chore: rename plugin registry key from engineering-standards to standards

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
     "review@passionfactory": true,
     "please@passionfactory": true,
     "testing@passionfactory": true,
-    "engineering-standards@passionfactory": true,
+    "standards@passionfactory": true,
     "tidy-first@passionfactory": true,
     "backend@passionfactory": true,
     "typescript-lsp@code-intelligence": true,


### PR DESCRIPTION
## Summary

- Update `.claude/settings.json` to use `standards@passionfactory` plugin registry key
- Replaces the previous `engineering-standards@passionfactory` key to align with the updated plugin namespace

## Test Plan

- [ ] Verify Claude Code loads the `standards@passionfactory` plugin correctly
- [ ] Confirm no plugin resolution errors after the rename

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the plugin key in .claude/settings.json from engineering-standards@passionfactory to standards@passionfactory. This aligns with the updated namespace and ensures the correct plugin loads without resolution errors.

- **Migration**
  - Update any local configs or docs that still reference engineering-standards@passionfactory.

<sup>Written for commit bc69cf38c436f9109a9262b7879086cd3be1d7d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

