### PR TITLE
fix(release): promote @pleaseai/soop from alpha to stable 0.1.31

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/soop": "0.1.31-alpha.1",
+  "packages/soop": "0.1.31",
   "packages/soop-native": "0.1.22",
   "packages/cli": "0.2.4",
   "packages/encoder": "0.3.2",

--- a/packages/soop/package.json
+++ b/packages/soop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pleaseai/soop",
-  "version": "0.1.31-alpha.1",
+  "version": "0.1.31",
   "description": "Repository Planning Graph - A unified framework for repository understanding and generation",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

- Removes the alpha prerelease tag from `@pleaseai/soop` version (`0.1.31-alpha.1` → `0.1.31`)
- Updates both `packages/soop/package.json` and `.release-please-manifest.json` to reflect stable version

## Problem

`npm publish` fails for prerelease versions (those with `-alpha`, `-beta`, etc. suffixes) unless the `--tag` flag is explicitly passed. This was causing publish failures in CI.

## Test Plan

- [ ] Verify `npm publish` succeeds without `--tag` flag after this change
- [ ] Confirm `.release-please-manifest.json` and `packages/soop/package.json` are in sync at `0.1.31`
- [ ] Check that release-please picks up the stable version correctly on next run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `@pleaseai/soop` to stable `0.1.31` to fix CI publish failures caused by prerelease tags. Updates `packages/soop/package.json` and `.release-please-manifest.json` so `npm publish` works without `--tag`.

<sup>Written for commit d7e7df92bb1c2d11d1ebddb1a8afdcbfcc16ea6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

