### PR TITLE
ci(soop): use @latest tag instead of @next for soop-encode workflow

### DIFF
--- a/.github/workflows/soop-encode.yml
+++ b/.github/workflows/soop-encode.yml
@@ -48,7 +48,7 @@ jobs:
           bun-version: latest
 
       - name: Install Repo Please
-        run: bun install -g @pleaseai/soop@next
+        run: bun install -g @pleaseai/soop@latest
 
       - name: Restore semantic cache
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5


### PR DESCRIPTION
## Summary

- Switches the `Install Repo Please` step in `.github/workflows/soop-encode.yml` from `@pleaseai/soop@next` to `@pleaseai/soop@latest`

## Problem

The `next` dist-tag is currently pinned to `0.1.26-alpha.1`, an older prerelease that reproducibly emits the following warning during the `soop evolve` post-evolution dependency-graph rebuild:

```
UNIQUE constraint failed: edges.source, edges.target, edges.type, edges.data_id
```

This happens because the pre-0.1.32 code did not clear existing dependency edges before calling `injectDependencies`, causing duplicate-edge insertion attempts.

## Fix

`latest` (currently `0.1.32`) ships the fix that clears existing dependency edges before rebuilding in `injectDependencies`. Using `@latest` also ensures the CI workflow automatically tracks subsequent stable releases rather than being stuck on an old alpha.

## Test Plan

- [ ] Observe the next triggered Soop Encode workflow run (push to main or manual trigger)
- [ ] Confirm the `soop evolve` step completes with no `UNIQUE constraint failed` warnings in the log
- [ ] Verify the workflow completes successfully end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Soop install in `.github/workflows/soop-encode.yml` from `@pleaseai/soop@next` to `@pleaseai/soop@latest` to eliminate evolve-time duplicate-edge warnings and track stable releases.

- **Bug Fixes**
  - `@next` is pinned to `0.1.26-alpha.1`, which didn’t clear dependency edges before rebuild and caused "UNIQUE constraint failed..." during `soop evolve`. `@latest` (>= `0.1.32`) includes the fix.

<sup>Written for commit 1336bd040eff901b9df3acf3558fd78fa8bf2c5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

