### PR TITLE
ci(soop): add force_encode input to soop-encode workflow

### DIFF
--- a/.github/workflows/soop-encode.yml
+++ b/.github/workflows/soop-encode.yml
@@ -2,6 +2,11 @@ name: Soop Encode
 
 on:
   workflow_dispatch:
+    inputs:
+      force_encode:
+        description: 'Force full re-encode, ignoring existing .soop/graph.json (use when graph is stale or corrupted)'
+        type: boolean
+        default: false
   push:
     branches: [main]
     paths:
@@ -60,8 +65,14 @@ jobs:
       - name: Encode or evolve RPG
         env:
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          FORCE_ENCODE: ${{ github.event.inputs.force_encode || 'false' }}
         run: |
-          if [ ! -f ".soop/graph.json" ]; then
+          if [ "$FORCE_ENCODE" = "true" ]; then
+            echo "force_encode=true — removing existing graph and running full encode"
+            rm -f .soop/graph.json .soop/graph.meta.json .soop/embeddings.json
+            mkdir -p .soop
+            soop encode . -o .soop/graph.json -m google/gemini-3.1-flash-lite-preview
+          elif [ ! -f ".soop/graph.json" ]; then
             echo "No existing graph — running full encode"
             mkdir -p .soop
             soop encode . -o .soop/graph.json -m google/gemini-3.1-flash-lite-preview


### PR DESCRIPTION
## Summary

- Add a `workflow_dispatch` boolean input `force_encode` (default: `false`) to the Soop Encode workflow.
- When `force_encode` is `true`, the encode step deletes any existing `.soop/graph.json`, `.soop/graph.meta.json`, and `.soop/embeddings.json` before running a full `soop encode`, bypassing the normal evolve-or-encode logic.
- Normal `push`-triggered runs and manual dispatches without the flag checked continue with the existing incremental evolve-or-encode behavior unchanged.

**Motivation:** The current `.soop/graph.json` contains 45 stale references to `scripts/launcher/mcp.ts`, which was deleted in #228 (`8dd7426`). Past incremental evolves never cleaned these up. This input provides a one-click recovery path via the GitHub Actions UI without requiring a manual intervention on the branch.

## Test plan

- [ ] Trigger the workflow manually via the GitHub Actions UI with `force_encode` unchecked — verify it follows the normal evolve path.
- [ ] Trigger the workflow manually with `force_encode` checked — verify it deletes the existing graph files and runs a clean full encode, producing a fresh `.soop/graph.json`.
- [ ] Verify a normal `push` to `main` is unaffected (evolve path still used when a graph already exists).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `force_encode` input to the Soop Encode workflow to allow a clean re-encode from the GitHub Actions UI. Defaults to off; existing evolve-or-encode behavior for `push` and manual runs stays the same.

- **New Features**
  - `workflow_dispatch` boolean `force_encode` (default `false`).
  - When `true`, removes existing `.soop/graph.json`, `.soop/graph.meta.json`, `.soop/embeddings.json` and runs a full `soop encode` (use for stale/corrupted graphs).

<sup>Written for commit bbb89c0c73dd8d4dc8a014f45b27059930028eef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

