### PR TITLE
ci: use client-id input for create-github-app-token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v5
         id: release

--- a/.github/workflows/soop-encode.yml
+++ b/.github/workflows/soop-encode.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

Silence the deprecation warning from `actions/create-github-app-token@v3` by renaming the deprecated `app-id` input to `client-id` across both CI workflow files.

## Changes

- `.github/workflows/release-please.yml` (line 32): `app-id` → `client-id`
- `.github/workflows/soop-encode.yml` (line 43): `app-id` → `client-id`

## Background

`actions/create-github-app-token@v3` deprecated the `app-id` input in favour of `client-id`. The action continues to accept the value under either name for now, so this is a non-breaking rename that only removes the deprecation warning from CI logs.

## Out of scope

The underlying secret (`secrets.APP_ID`) is unchanged. Strictly speaking, that secret should eventually hold the App's Client ID (`Iv23li...` format) rather than the numeric App ID. That secret-value migration is a separate concern and is **not** addressed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the deprecated app-id input with client-id for `actions/create-github-app-token@v3` in release-please.yml and soop-encode.yml to silence CI deprecation warnings. No behavior change; the workflows still pass through `${{ secrets.APP_ID }}`.

<sup>Written for commit 6db4715820fb308cb7fbfb909b893b98d5eeea70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

