### PR TITLE
ci: switch app token secret from APP_ID to CLIENT_ID

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v5
         id: release

--- a/.github/workflows/soop-encode.yml
+++ b/.github/workflows/soop-encode.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

The `release-please` workflow was failing with **"Resource not accessible by integration"** when creating GitHub releases.

## Root Cause

`actions/create-github-app-token@v3` uses a `client-id` parameter that expects the GitHub App's **Client ID** — a string like `Iv23li...`. This is *not* the same as the numeric **App ID**.

The secret was previously named `APP_ID`, which implied it held the numeric App ID, but it actually held the Client ID value. This naming mismatch caused confusion and was the source of the permission error.

## Fix

Renamed the secret reference from `APP_ID` to `CLIENT_ID` in both workflows that use an App token:

| File | Line | Change |
|------|------|--------|
| `.github/workflows/release-please.yml` | 32 | `secrets.APP_ID` → `secrets.CLIENT_ID` |
| `.github/workflows/soop-encode.yml` | 43 | `secrets.APP_ID` → `secrets.CLIENT_ID` |

`ci.yml` is unaffected — it does not use App token authentication.

## Action Required

Before these workflows will succeed, the repository/org secret must be updated:

1. Delete (or rename) the existing `APP_ID` secret.
2. Create a new secret named **`CLIENT_ID`** with the GitHub App's Client ID value (the `Iv23li...` string found on the App's settings page, **not** the numeric App ID).

The `PRIVATE_KEY` secret is unchanged and does not need to be updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release-please failures by passing the GitHub App Client ID to `actions/create-github-app-token@v3`. Switch workflows to use `secrets.CLIENT_ID` instead of `secrets.APP_ID` to resolve “Resource not accessible by integration.”

- **Bug Fixes**
  - `.github/workflows/release-please.yml`: `client-id: ${{ secrets.CLIENT_ID }}`
  - `.github/workflows/soop-encode.yml`: `client-id: ${{ secrets.CLIENT_ID }}`

- **Migration**
  - Create a secret `CLIENT_ID` with the GitHub App’s Client ID (the `Iv...` string).
  - Remove or rename the old `APP_ID` secret. `PRIVATE_KEY` is unchanged.

<sup>Written for commit d4efeaccf0e2b8363478f495ec3d71485627a834. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

