### PR TITLE
fix(ci): correct pleaseai-bot name typo in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,8 +57,8 @@ jobs:
             echo "bun.lock is already up to date"
             exit 0
           fi
-          git config user.name "pleaeai-bot[bot]"
-          git config user.email "239696668+pleaeai-bot[bot]@users.noreply.github.com"
+          git config user.name "pleaseai-bot[bot]"
+          git config user.email "239696668+pleaseai-bot[bot]@users.noreply.github.com"
           git add bun.lock
           git commit -m "chore: update bun.lock"
           git push


### PR DESCRIPTION
## Summary

The release-please workflow's bot git config contained a typo: `pleaeai-bot[bot]` (missing the letter `s`) in both `user.name` and `user.email`. This caused the release-please bun.lock update commits to be authored under the wrong identity.

## Changes

- Corrected `user.name` from `pleaeai-bot[bot]` to `pleaseai-bot[bot]`
- Corrected `user.email` from `239696668+pleaeai-bot[bot]@users.noreply.github.com` to `239696668+pleaseai-bot[bot]@users.noreply.github.com`

## Test Plan

- [x] No functional code changes — CI workflow config only
- [x] Verified diff is limited to the two typo corrections

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the bot identity in the `release-please` workflow by correcting the typo from `pleaeai-bot[bot]` to `pleaseai-bot[bot]` in `git config` for `user.name` and `user.email`. This ensures `bun.lock` update commits are authored by the correct bot.

<sup>Written for commit f3eec854290a0670b854da830ac843bf409d3a0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

