### PR TITLE
ci: Update release-please.yml with additional permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,10 @@ jobs:
   release-please:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write    
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       paths_released: ${{ steps.release.outputs.paths_released }}


### PR DESCRIPTION
Added permissions for contents, pull-requests, and id-token in release-please workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit permissions to the `release-please` workflow so it can create release PRs, push release commits/tags, and use OIDC when needed. Adds `contents: write`, `pull-requests: write`, and `id-token: write`.

<sup>Written for commit a60aab1a895d361ecf1da9e2892b37086434fe11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

