### PR TITLE
feat(mcp): add soop_tree, fuzzy suggestions, and RPG-Kit parity fixes

### DIFF
--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -13,7 +13,8 @@
     "./adapters": "./src/adapters.ts",
     "./embeddings": "./src/embeddings.ts",
     "./meta": "./src/meta.ts",
-    "./python-format": "./src/python-format.ts"
+    "./python-format": "./src/python-format.ts",
+    "./fuzzy": "./src/fuzzy.ts"
   },
   "dependencies": {
     "@pleaseai/soop-store": "workspace:*",

--- a/packages/graph/src/fuzzy.ts
+++ b/packages/graph/src/fuzzy.ts
@@ -1,5 +1,6 @@
 import type { Node } from './node'
 import type { RepositoryPlanningGraph } from './rpg'
+import path from 'node:path'
 
 /**
  * Maximum suggestions returned by suggestNodes.
@@ -183,14 +184,15 @@ async function collectCandidateNodes(
 function deriveName(node: Node): string {
   if (node.metadata?.qualifiedName)
     return node.metadata.qualifiedName
-  const path = node.metadata?.path
-  if (path) {
-    const parts = path.split('/').filter(Boolean)
-    return parts.at(-1) ?? path
+  const nodePath = node.metadata?.path
+  if (nodePath) {
+    const parts = nodePath.split(path.sep).join('/').split('/').filter(Boolean)
+    return parts.at(-1) ?? nodePath
   }
   if ('directoryPath' in node && node.directoryPath) {
-    const parts = node.directoryPath.split('/').filter(Boolean)
-    return parts.at(-1) ?? node.directoryPath
+    const dirPath = node.directoryPath as string
+    const parts = dirPath.split(path.sep).join('/').split('/').filter(Boolean)
+    return parts.at(-1) ?? dirPath
   }
   return node.feature.description
 }

--- a/packages/graph/src/fuzzy.ts
+++ b/packages/graph/src/fuzzy.ts
@@ -1,0 +1,196 @@
+import type { Node } from './node'
+import type { RepositoryPlanningGraph } from './rpg'
+
+/**
+ * Maximum suggestions returned by suggestNodes.
+ */
+const DEFAULT_SUGGEST_LIMIT = 5
+
+/**
+ * Compute Levenshtein distance between two strings.
+ * Lower is more similar; 0 means identical.
+ */
+export function levenshteinDistance(a: string, b: string): number {
+  if (a === b)
+    return 0
+  if (a.length === 0)
+    return b.length
+  if (b.length === 0)
+    return a.length
+
+  let prev: number[] = Array.from<number>({ length: b.length + 1 })
+  let curr: number[] = Array.from<number>({ length: b.length + 1 })
+  for (let j = 0; j <= b.length; j++) prev[j] = j
+
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      curr[j] = Math.min(
+        curr[j - 1]! + 1,
+        prev[j]! + 1,
+        prev[j - 1]! + cost,
+      )
+    }
+    const tmp = prev
+    prev = curr
+    curr = tmp
+  }
+
+  return prev[b.length]!
+}
+
+/**
+ * Compute a similarity ratio in [0, 100] between two strings.
+ * 100 means identical; 0 means completely different.
+ */
+export function similarityRatio(a: string, b: string): number {
+  if (a.length === 0 && b.length === 0)
+    return 100
+  const distance = levenshteinDistance(a.toLowerCase(), b.toLowerCase())
+  const maxLen = Math.max(a.length, b.length)
+  return Math.round(((maxLen - distance) / maxLen) * 100)
+}
+
+/**
+ * Score a candidate string against a query.
+ * Higher is better. Combines substring containment and Levenshtein similarity.
+ *
+ * Tiers (mirrors Python rapidfuzz-based suggestion ordering):
+ *   100 — exact match
+ *    90 — query is a prefix or suffix of candidate
+ *    80 — query is a substring of candidate
+ *    60 — candidate is a substring of query
+ *  0-55 — Levenshtein-similarity-scaled (so substring always beats fuzzy)
+ */
+export function scoreCandidate(query: string, candidate: string): number {
+  if (!query || !candidate)
+    return 0
+  const q = query.toLowerCase()
+  const c = candidate.toLowerCase()
+
+  if (q === c)
+    return 100
+  if (c.startsWith(q) || c.endsWith(q))
+    return 90
+  if (c.includes(q))
+    return 80
+  if (q.includes(c))
+    return 60
+
+  // Levenshtein-based fuzzy score, capped below substring tier
+  const raw = similarityRatio(q, c)
+  return Math.round(raw * 0.55)
+}
+
+/**
+ * Options for suggestNodes
+ */
+export interface SuggestOptions {
+  /** Maximum number of suggestions to return (default 5) */
+  limit?: number
+  /** Restrict suggestions to a subtree by node ID (functional descendants) */
+  scope?: string
+  /** Minimum score (0-100) for a suggestion to be included (default 30) */
+  minScore?: number
+}
+
+/**
+ * Internal scoring entry
+ */
+interface ScoredId {
+  id: string
+  score: number
+}
+
+/**
+ * Score nodes against a query string.
+ * Combines best score of (id, name, feature.description).
+ */
+export function rankNodes(query: string, nodes: Node[]): ScoredId[] {
+  const scored: ScoredId[] = []
+  for (const node of nodes) {
+    const name = deriveName(node)
+    const idScore = scoreCandidate(query, node.id)
+    const nameScore = scoreCandidate(query, name)
+    const descScore = scoreCandidate(query, node.feature.description)
+    const best = Math.max(idScore, nameScore, descScore)
+    if (best > 0) {
+      scored.push({ id: node.id, score: best })
+    }
+  }
+  scored.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
+  return scored
+}
+
+/**
+ * Suggest node IDs that closely match a query string.
+ *
+ * Ordering mirrors the Python `_suggest_dep_nodes` + `_suggest_rpg_nodes`
+ * helpers: substring matches on ID and name come first, then fuzzy
+ * Levenshtein matches as a fallback.
+ *
+ * Returns up to `limit` node IDs.
+ */
+export async function suggestNodes(
+  rpg: RepositoryPlanningGraph,
+  query: string,
+  options: SuggestOptions = {},
+): Promise<string[]> {
+  const limit = options.limit ?? DEFAULT_SUGGEST_LIMIT
+  const minScore = options.minScore ?? 30
+  const trimmed = query.trim()
+  if (!trimmed)
+    return []
+
+  const nodes = await collectCandidateNodes(rpg, options.scope)
+  const ranked = rankNodes(trimmed, nodes).filter(entry => entry.score >= minScore)
+  return ranked.slice(0, limit).map(entry => entry.id)
+}
+
+async function collectCandidateNodes(
+  rpg: RepositoryPlanningGraph,
+  scope?: string,
+): Promise<Node[]> {
+  if (!scope) {
+    return rpg.getNodes()
+  }
+
+  const result: Node[] = []
+  const seen = new Set<string>()
+  const stack = [scope]
+  while (stack.length > 0) {
+    const current = stack.pop()!
+    if (seen.has(current))
+      continue
+    seen.add(current)
+    const node = await rpg.getNode(current)
+    if (!node)
+      continue
+    result.push(node)
+    const children = await rpg.getChildren(current)
+    for (const child of children) {
+      if (!seen.has(child.id))
+        stack.push(child.id)
+    }
+  }
+  return result
+}
+
+/**
+ * Derive a display-name candidate from a node for scoring purposes.
+ */
+function deriveName(node: Node): string {
+  if (node.metadata?.qualifiedName)
+    return node.metadata.qualifiedName
+  const path = node.metadata?.path
+  if (path) {
+    const parts = path.split('/').filter(Boolean)
+    return parts.at(-1) ?? path
+  }
+  if ('directoryPath' in node && node.directoryPath) {
+    const parts = node.directoryPath.split('/').filter(Boolean)
+    return parts.at(-1) ?? node.directoryPath
+  }
+  return node.feature.description
+}

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -26,6 +26,17 @@ export {
 
 export type { BaseEdge, DataFlowEdge, DependencyEdge, Edge, FunctionalEdge } from './edge'
 
+// Fuzzy matching + node suggestions
+export {
+  levenshteinDistance,
+  rankNodes,
+  scoreCandidate,
+  similarityRatio,
+  suggestNodes,
+} from './fuzzy'
+
+export type { SuggestOptions } from './fuzzy'
+
 // JSONL format (git-friendly graph serialization)
 export { parseGraphJsonl, serializeGraphJsonl } from './jsonl'
 

--- a/packages/graph/tests/fuzzy.test.ts
+++ b/packages/graph/tests/fuzzy.test.ts
@@ -1,0 +1,140 @@
+import { RepositoryPlanningGraph } from '@pleaseai/soop-graph'
+import {
+  levenshteinDistance,
+  rankNodes,
+  scoreCandidate,
+  similarityRatio,
+  suggestNodes,
+} from '@pleaseai/soop-graph/fuzzy'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('levenshteinDistance', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshteinDistance('abc', 'abc')).toBe(0)
+  })
+
+  it('returns length when one string is empty', () => {
+    expect(levenshteinDistance('', 'hello')).toBe(5)
+    expect(levenshteinDistance('hello', '')).toBe(5)
+  })
+
+  it('counts single substitution', () => {
+    expect(levenshteinDistance('kitten', 'sitten')).toBe(1)
+  })
+
+  it('counts classic kitten/sitting case', () => {
+    expect(levenshteinDistance('kitten', 'sitting')).toBe(3)
+  })
+})
+
+describe('similarityRatio', () => {
+  it('is 100 for identical strings', () => {
+    expect(similarityRatio('abc', 'abc')).toBe(100)
+  })
+
+  it('is case-insensitive', () => {
+    expect(similarityRatio('ABC', 'abc')).toBe(100)
+  })
+
+  it('returns lower scores for distant strings', () => {
+    const low = similarityRatio('abc', 'xyz')
+    expect(low).toBeLessThan(50)
+  })
+})
+
+describe('scoreCandidate', () => {
+  it('scores exact match as 100', () => {
+    expect(scoreCandidate('hello', 'hello')).toBe(100)
+  })
+
+  it('scores prefix/suffix matches above plain substring', () => {
+    const prefix = scoreCandidate('auth', 'authentication')
+    const inside = scoreCandidate('hen', 'authentication')
+    expect(prefix).toBeGreaterThan(inside)
+  })
+
+  it('scores substring above fuzzy match', () => {
+    const sub = scoreCandidate('auth', 'do_auth_check')
+    const fuzz = scoreCandidate('auht', 'authentication') // typo
+    expect(sub).toBeGreaterThan(fuzz)
+  })
+
+  it('returns 0 when query or candidate is empty', () => {
+    expect(scoreCandidate('', 'abc')).toBe(0)
+    expect(scoreCandidate('abc', '')).toBe(0)
+  })
+})
+
+describe('rankNodes + suggestNodes', () => {
+  let rpg: RepositoryPlanningGraph
+
+  beforeEach(async () => {
+    rpg = await RepositoryPlanningGraph.create({ name: 'test-repo' })
+
+    await rpg.addHighLevelNode({
+      id: 'authentication-module',
+      feature: { description: 'handle user authentication' },
+      directoryPath: '/src/auth',
+    })
+    await rpg.addHighLevelNode({
+      id: 'authorization-module',
+      feature: { description: 'role-based access control' },
+      directoryPath: '/src/authz',
+    })
+    await rpg.addLowLevelNode({
+      id: 'login.ts',
+      feature: { description: 'login entry point' },
+      metadata: { entityType: 'file', path: '/src/auth/login.ts' },
+    })
+  })
+
+  it('orders substring matches before fuzzy matches', async () => {
+    const all = await rpg.getNodes()
+    const ranked = rankNodes('auth', all)
+
+    expect(ranked[0]?.score).toBeGreaterThanOrEqual(ranked[1]?.score ?? 0)
+    // 'authentication-module' and 'authorization-module' both contain 'auth' as substring
+    expect(ranked.slice(0, 2).map(r => r.id)).toEqual(
+      expect.arrayContaining(['authentication-module', 'authorization-module']),
+    )
+  })
+
+  it('returns suggestions for typo (fuzzy)', async () => {
+    const suggestions = await suggestNodes(rpg, 'authentcation', { limit: 5 })
+
+    expect(suggestions).toContain('authentication-module')
+  })
+
+  it('returns substring matches first for shared prefix', async () => {
+    const suggestions = await suggestNodes(rpg, 'auth', { limit: 5 })
+
+    // Both auth-* modules should come back; login.ts (no 'auth' in id) may also match via path
+    expect(suggestions.length).toBeGreaterThanOrEqual(2)
+    expect(suggestions).toContain('authentication-module')
+    expect(suggestions).toContain('authorization-module')
+  })
+
+  it('respects the limit option', async () => {
+    const suggestions = await suggestNodes(rpg, 'auth', { limit: 1 })
+
+    expect(suggestions.length).toBe(1)
+  })
+
+  it('returns empty array for empty query', async () => {
+    const suggestions = await suggestNodes(rpg, '   ', { limit: 5 })
+
+    expect(suggestions).toEqual([])
+  })
+
+  it('respects scope by limiting to the subtree', async () => {
+    await rpg.addFunctionalEdge({ source: 'authentication-module', target: 'login.ts' })
+
+    const scoped = await suggestNodes(rpg, 'authoriz', {
+      limit: 5,
+      scope: 'authentication-module',
+    })
+
+    // authorization-module is outside the auth subtree, so it must not appear
+    expect(scoped).not.toContain('authorization-module')
+  })
+})

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -22,6 +22,7 @@ import {
   executeFetch,
   executeSearch,
   executeStats,
+  executeTree,
   ExploreInputSchema,
   FetchInputBaseSchema,
   FetchInputSchema,
@@ -30,6 +31,7 @@ import {
   SOOP_TOOL_ANNOTATIONS,
   SOOP_TOOLS,
   StatsInputSchema,
+  TreeInputSchema,
 } from './tools'
 
 const log = createStderrLogger('MCP')
@@ -227,6 +229,21 @@ export function createMcpServer(
         const rpg = await requireRpg(state)
         const result = await executeStats(rpg)
         return { result, summary: { name: result.name } }
+      }),
+  )
+
+  server.registerTool(
+    SOOP_TOOLS.soop_tree.name,
+    {
+      description: SOOP_TOOLS.soop_tree.description,
+      inputSchema: TreeInputSchema.shape,
+      annotations: SOOP_TOOL_ANNOTATIONS.soop_tree,
+    },
+    async args =>
+      wrapHandler('soop_tree', args, async () => {
+        const rpg = await requireRpg(state)
+        const result = await executeTree(rpg, TreeInputSchema.parse(args))
+        return { result, summary: {} }
       }),
   )
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -11,8 +11,9 @@ import { RPGEvolver } from '@pleaseai/soop-encoder/evolution/evolve'
 import { ExploreRPG } from '@pleaseai/soop-tools/explore'
 import { FetchNode } from '@pleaseai/soop-tools/fetch'
 import { SearchNode } from '@pleaseai/soop-tools/search'
+import { RPGTree } from '@pleaseai/soop-tools/tree'
 import { z } from 'zod/v4'
-import { encodeFailedError, evolveFailedError, invalidInputError, invalidPathError, nodeNotFoundError, RPGError, rpgNotLoadedError } from './errors'
+import { encodeFailedError, evolveFailedError, invalidInputError, invalidPathError, RPGError, rpgNotLoadedError } from './errors'
 
 /**
  * Input schema for soop_search tool
@@ -27,6 +28,12 @@ export const SearchInputSchema = z.object({
     .optional()
     .describe(
       'Search strategy for feature search. Defaults to hybrid when semantic search is available.',
+    ),
+  fuzzyFallback: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, falls back to fuzzy node-suggestion matching if the primary search returns no results. Off by default.',
     ),
 })
 
@@ -61,6 +68,12 @@ export const ExploreInputSchema = z.object({
   maxDepth: z.number().default(3),
   direction: z.enum(['downstream', 'upstream', 'both']).default('downstream'),
   dependencyType: z.enum(['import', 'call', 'inherit', 'implement', 'use']).optional().describe('Filter dependency edges by their dependency type'),
+  maxEdges: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Maximum edges returned before truncation (default: 20). When exceeded, the result sets truncated:true.'),
 })
 
 export type ExploreInput = z.infer<typeof ExploreInputSchema>
@@ -96,6 +109,24 @@ export type EvolveInput = z.infer<typeof EvolveInputSchema>
 export const StatsInputSchema = z.object({})
 
 export type StatsInput = z.infer<typeof StatsInputSchema>
+
+/**
+ * Input schema for soop_tree tool
+ */
+export const TreeInputSchema = z.object({
+  rootId: z
+    .string()
+    .optional()
+    .describe('Starting node ID. Defaults to top-level nodes (synthetic root if multiple).'),
+  maxDepth: z
+    .number()
+    .int()
+    .min(0)
+    .default(2)
+    .describe('Maximum depth to expand. Children beyond this depth report childrenCount only.'),
+})
+
+export type TreeInput = z.infer<typeof TreeInputSchema>
 
 /**
  * Server-level instructions surfaced via MCP `initialize` so the agent
@@ -144,6 +175,7 @@ export const SOOP_TOOL_ANNOTATIONS = {
   soop_fetch: { readOnlyHint: true, openWorldHint: false, idempotentHint: true },
   soop_explore: { readOnlyHint: true, openWorldHint: false, idempotentHint: true },
   soop_stats: { readOnlyHint: true, openWorldHint: false, idempotentHint: true },
+  soop_tree: { readOnlyHint: true, openWorldHint: false, idempotentHint: true },
   soop_encode: { readOnlyHint: false, destructiveHint: false, openWorldHint: true, idempotentHint: false },
   soop_evolve: { readOnlyHint: false, destructiveHint: false, openWorldHint: true, idempotentHint: false },
 } as const
@@ -188,6 +220,12 @@ export const SOOP_TOOLS = {
       'Get statistics about the loaded Repository Planning Graph including node counts, edge counts, and structural breakdown.',
     inputSchema: StatsInputSchema,
   },
+  soop_tree: {
+    name: 'soop_tree',
+    description:
+      'List the feature hierarchy as a nested tree. Best entry point for orienting in an unfamiliar codebase. Returns {id, name, type, path, children?} with childrenCount when truncated by maxDepth. When rootId is omitted, returns the top-level structure (synthetic root if the graph has multiple roots).',
+    inputSchema: TreeInputSchema,
+  },
 } as const
 
 /**
@@ -209,6 +247,7 @@ export async function executeSearch(
     filePattern: input.filePattern,
     searchScopes: input.searchScopes,
     searchStrategy: input.searchStrategy as SearchStrategy | undefined,
+    fuzzyFallback: input.fuzzyFallback,
   })
 
   return {
@@ -220,6 +259,7 @@ export async function executeSearch(
     })),
     totalMatches: result.totalMatches,
     mode: result.mode,
+    ...(result.fuzzy ? { fuzzy: true } : {}),
   }
 }
 
@@ -247,8 +287,10 @@ export async function executeFetch(rpg: RepositoryPlanningGraph | null, input: F
       },
       sourceCode: entity.sourceCode,
       featurePaths: entity.featurePaths,
+      ...(entity.allFeatures ? { allFeatures: entity.allFeatures } : {}),
     })),
     notFound: result.notFound,
+    ...(result.suggestions ? { suggestions: result.suggestions } : {}),
   }
 }
 
@@ -260,11 +302,6 @@ export async function executeExplore(rpg: RepositoryPlanningGraph | null, input:
     throw rpgNotLoadedError()
   }
 
-  const startNodeExists = await rpg.hasNode(input.startNode)
-  if (!startNodeExists) {
-    throw nodeNotFoundError(input.startNode)
-  }
-
   const explorer = new ExploreRPG(rpg)
   const result = await explorer.traverse({
     startNode: input.startNode,
@@ -272,6 +309,7 @@ export async function executeExplore(rpg: RepositoryPlanningGraph | null, input:
     maxDepth: input.maxDepth,
     direction: input.direction,
     dependencyType: input.dependencyType,
+    maxEdges: input.maxEdges,
   })
 
   return {
@@ -283,6 +321,9 @@ export async function executeExplore(rpg: RepositoryPlanningGraph | null, input:
     })),
     edges: result.edges,
     maxDepthReached: result.maxDepthReached,
+    ...(result.notFound ? { notFound: result.notFound } : {}),
+    ...(result.suggestions ? { suggestions: result.suggestions } : {}),
+    ...(result.truncated ? { truncated: true } : {}),
   }
 }
 
@@ -385,4 +426,19 @@ export async function executeStats(rpg: RepositoryPlanningGraph | null) {
     name: config.name,
     ...stats,
   }
+}
+
+/**
+ * Execute soop_tree tool
+ */
+export async function executeTree(rpg: RepositoryPlanningGraph | null, input: TreeInput) {
+  if (!rpg) {
+    throw rpgNotLoadedError()
+  }
+
+  const tree = new RPGTree(rpg)
+  return tree.list({
+    rootId: input.rootId,
+    maxDepth: input.maxDepth,
+  })
 }

--- a/packages/mcp/tests/mcp.test.ts
+++ b/packages/mcp/tests/mcp.test.ts
@@ -19,10 +19,12 @@ import {
   executeFetch,
   executeSearch,
   executeStats,
+  executeTree,
   ExploreInputSchema,
   FetchInputSchema,
   SearchInputSchema,
   StatsInputSchema,
+  TreeInputSchema,
 } from '@pleaseai/soop-mcp/tools'
 import { beforeEach, describe, expect, it } from 'vitest'
 
@@ -405,15 +407,16 @@ describe('MCP Tool Execution', () => {
       ).rejects.toThrow(RPGError)
     })
 
-    it('should throw when start node not found', async () => {
-      await expect(
-        executeExplore(rpg, {
-          startNode: 'nonexistent',
-          edgeType: 'all',
-          maxDepth: 3,
-          direction: 'downstream',
-        }),
-      ).rejects.toThrow(RPGError)
+    it('returns notFound (no throw) when start node does not exist', async () => {
+      const result = await executeExplore(rpg, {
+        startNode: 'nonexistent',
+        edgeType: 'all',
+        maxDepth: 3,
+        direction: 'downstream',
+      })
+      expect(result.nodes).toEqual([])
+      expect(result.edges).toEqual([])
+      expect((result as { notFound?: string }).notFound).toBe('nonexistent')
     })
 
     it('should explore from root node', async () => {
@@ -496,5 +499,43 @@ describe('MCP Tool Execution', () => {
       expect(result.highLevelNodeCount).toBeGreaterThan(0)
       expect(result.lowLevelNodeCount).toBeGreaterThan(0)
     })
+  })
+
+  describe('executeTree', () => {
+    it('throws when RPG is null', async () => {
+      await expect(executeTree(null, { maxDepth: 2 })).rejects.toThrow(RPGError)
+    })
+
+    it('returns a nested tree with totalNodes count', async () => {
+      const result = await executeTree(rpg, { maxDepth: 2 })
+
+      expect(result.root).not.toBeNull()
+      expect(result.totalNodes).toBeGreaterThan(0)
+    })
+
+    it('returns suggestions when rootId is unknown', async () => {
+      const result = await executeTree(rpg, { rootId: 'totally-bogus-node-xyz', maxDepth: 2 })
+
+      expect(result.root).toBeNull()
+      expect(result.notFound).toBe('totally-bogus-node-xyz')
+    })
+  })
+})
+
+describe('treeInputSchema', () => {
+  it('applies default maxDepth of 2', () => {
+    const parsed = TreeInputSchema.parse({})
+    expect(parsed.maxDepth).toBe(2)
+    expect(parsed.rootId).toBeUndefined()
+  })
+
+  it('accepts an explicit rootId', () => {
+    const parsed = TreeInputSchema.parse({ rootId: 'root', maxDepth: 5 })
+    expect(parsed.rootId).toBe('root')
+    expect(parsed.maxDepth).toBe(5)
+  })
+
+  it('rejects negative maxDepth', () => {
+    expect(() => TreeInputSchema.parse({ maxDepth: -1 })).toThrow()
   })
 })

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -9,7 +9,8 @@
     ".": "./src/index.ts",
     "./search": "./src/search.ts",
     "./fetch": "./src/fetch.ts",
-    "./explore": "./src/explore.ts"
+    "./explore": "./src/explore.ts",
+    "./tree": "./src/tree.ts"
   },
   "dependencies": {
     "@pleaseai/soop-graph": "workspace:*",

--- a/packages/tools/src/explore.ts
+++ b/packages/tools/src/explore.ts
@@ -219,7 +219,8 @@ export class ExploreRPG {
     for (const edge of await this.rpg.getOutEdges(nodeId, edgeType)) {
       if (!this.matchesDependencyType(edge, dependencyType))
         continue
-      this.addEdge(edge, state)
+      if (!this.addEdge(edge, state))
+        return
       await this.exploreNode(edge.target, depth + 1, maxDepth, direction, edgeTypes, state, dependencyType)
     }
   }
@@ -240,23 +241,27 @@ export class ExploreRPG {
     for (const edge of await this.rpg.getInEdges(nodeId, edgeType)) {
       if (!this.matchesDependencyType(edge, dependencyType))
         continue
-      this.addEdge(edge, state)
+      if (!this.addEdge(edge, state))
+        return
       await this.exploreNode(edge.source, depth + 1, maxDepth, direction, edgeTypes, state, dependencyType)
     }
   }
 
   /**
    * Add an edge to the state, respecting the maxEdges cap.
+   * Returns true if the edge was added, false when the cap is reached
+   * so callers can stop further traversal.
    */
-  private addEdge(edge: Edge, state: ExploreState): void {
+  private addEdge(edge: Edge, state: ExploreState): boolean {
     if (state.edges.length >= state.maxEdges) {
       state.truncated = true
-      return
+      return false
     }
     state.edges.push({
       source: edge.source,
       target: edge.target,
       type: edge.type,
     })
+    return true
   }
 }

--- a/packages/tools/src/explore.ts
+++ b/packages/tools/src/explore.ts
@@ -1,10 +1,17 @@
 import type { DependencyEdge, Edge, Node, RepositoryPlanningGraph } from '@pleaseai/soop-graph'
 import { EdgeType, isDependencyEdge } from '@pleaseai/soop-graph'
+import { suggestNodes } from '@pleaseai/soop-graph/fuzzy'
 
 /**
  * Edge type for exploration
  */
 export type ExploreEdgeType = 'containment' | 'dependency' | 'data_flow' | 'all'
+
+/**
+ * Default maximum edges returned before truncation kicks in.
+ * Mirrors Python `_MAX_EXPLORE_EDGES`.
+ */
+export const DEFAULT_MAX_EXPLORE_EDGES = 20
 
 /**
  * Options for ExploreRPG
@@ -20,6 +27,8 @@ export interface ExploreOptions {
   direction?: 'downstream' | 'upstream' | 'both'
   /** Filter dependency edges by their dependency type */
   dependencyType?: 'import' | 'call' | 'inherit' | 'implement' | 'use'
+  /** Maximum edges to collect before truncating (default: 20) */
+  maxEdges?: number
 }
 
 /**
@@ -32,6 +41,12 @@ export interface ExploreResult {
   edges: Array<{ source: string, target: string, type: string }>
   /** Depth reached */
   maxDepthReached: number
+  /** Requested startNode that could not be found */
+  notFound?: string
+  /** Suggested similar node IDs when startNode was not found */
+  suggestions?: string[]
+  /** Set to true when edge collection was capped by maxEdges (default 20) */
+  truncated?: boolean
 }
 
 /**
@@ -42,6 +57,8 @@ interface ExploreState {
   nodes: Node[]
   edges: Array<{ source: string, target: string, type: string }>
   maxDepthReached: number
+  maxEdges: number
+  truncated: boolean
 }
 
 /**
@@ -61,23 +78,51 @@ export class ExploreRPG {
    * Traverse the graph from a starting node
    */
   async traverse(options: ExploreOptions): Promise<ExploreResult> {
-    const { startNode, edgeType, maxDepth = 3, direction = 'downstream', dependencyType } = options
+    const {
+      startNode,
+      edgeType,
+      maxDepth = 3,
+      direction = 'downstream',
+      dependencyType,
+      maxEdges = DEFAULT_MAX_EXPLORE_EDGES,
+    } = options
+
+    const exists = await this.rpg.hasNode(startNode)
+    if (!exists) {
+      const suggestions = await suggestNodes(this.rpg, startNode, { limit: 5 })
+      const result: ExploreResult = {
+        nodes: [],
+        edges: [],
+        maxDepthReached: 0,
+        notFound: startNode,
+      }
+      if (suggestions.length > 0) {
+        result.suggestions = suggestions
+      }
+      return result
+    }
 
     const state: ExploreState = {
       visited: new Set<string>(),
       nodes: [],
       edges: [],
       maxDepthReached: 0,
+      maxEdges,
+      truncated: false,
     }
 
     const edgeTypes = this.resolveEdgeTypes(edgeType)
     await this.exploreNode(startNode, 0, maxDepth, direction, edgeTypes, state, dependencyType)
 
-    return {
+    const result: ExploreResult = {
       nodes: state.nodes,
       edges: state.edges,
       maxDepthReached: state.maxDepthReached,
     }
+    if (state.truncated) {
+      result.truncated = true
+    }
+    return result
   }
 
   /**
@@ -201,9 +246,13 @@ export class ExploreRPG {
   }
 
   /**
-   * Add an edge to the state
+   * Add an edge to the state, respecting the maxEdges cap.
    */
   private addEdge(edge: Edge, state: ExploreState): void {
+    if (state.edges.length >= state.maxEdges) {
+      state.truncated = true
+      return
+    }
     state.edges.push({
       source: edge.source,
       target: edge.target,

--- a/packages/tools/src/fetch.ts
+++ b/packages/tools/src/fetch.ts
@@ -2,6 +2,7 @@ import type { GitHubSource, RepositoryPlanningGraph } from '@pleaseai/soop-graph
 import type { Node } from '@pleaseai/soop-graph/node'
 import { readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
+import { suggestNodes } from '@pleaseai/soop-graph/fuzzy'
 
 /**
  * Source resolution mode for FetchNode
@@ -28,6 +29,12 @@ export interface EntityDetail {
   sourceCode?: string
   /** Related feature paths */
   featurePaths: string[]
+  /**
+   * For file-type nodes: distinct feature descriptions implemented by
+   * descendant entities (classes, functions, methods inside the file).
+   * Mirrors the Python `get_node_detail`/`all_features` aggregation.
+   */
+  allFeatures?: string[]
 }
 
 /**
@@ -38,6 +45,8 @@ export interface FetchResult {
   entities: EntityDetail[]
   /** Entities not found */
   notFound: string[]
+  /** Suggested similar node IDs aggregated across all notFound entries (up to 5) */
+  suggestions?: string[]
 }
 
 /**
@@ -101,18 +110,50 @@ export class FetchNode {
       const node = await this.rpg.getNode(id)
       if (node) {
         const sourceCode = await this.readSource(node)
-        entities.push({
+        const detail: EntityDetail = {
           node,
           sourceCode,
           featurePaths: await this.getFeaturePaths(node.id),
-        })
+        }
+        if (node.metadata?.entityType === 'file') {
+          const allFeatures = await this.aggregateDescendantFeatures(node.id)
+          if (allFeatures.length > 0) {
+            detail.allFeatures = allFeatures
+          }
+        }
+        entities.push(detail)
       }
       else {
         notFound.push(id)
       }
     }
 
-    return { entities, notFound }
+    if (notFound.length === 0) {
+      return { entities, notFound }
+    }
+
+    const suggestions = await this.collectSuggestions(notFound)
+    return suggestions.length > 0
+      ? { entities, notFound, suggestions }
+      : { entities, notFound }
+  }
+
+  /**
+   * Aggregate suggestions across all not-found IDs, deduplicated and ranked.
+   */
+  private async collectSuggestions(notFound: string[]): Promise<string[]> {
+    const seen = new Set<string>()
+    const ordered: string[] = []
+    for (const id of notFound) {
+      const suggestions = await suggestNodes(this.rpg, id, { limit: 5 })
+      for (const suggestion of suggestions) {
+        if (!seen.has(suggestion)) {
+          seen.add(suggestion)
+          ordered.push(suggestion)
+        }
+      }
+    }
+    return ordered.slice(0, 5)
   }
 
   /**
@@ -197,6 +238,31 @@ export class FetchNode {
       return lines.slice(startLine - 1, endLine).join('\n')
     }
     return content
+  }
+
+  /**
+   * Aggregate distinct feature descriptions from all descendants of a file node.
+   * Mirrors Python `get_node_detail` for `type=file`.
+   */
+  private async aggregateDescendantFeatures(fileNodeId: string): Promise<string[]> {
+    const collected = new Set<string>()
+    const stack = [fileNodeId]
+    const visited = new Set<string>()
+    while (stack.length > 0) {
+      const current = stack.pop()!
+      if (visited.has(current))
+        continue
+      visited.add(current)
+      const children = await this.rpg.getChildren(current)
+      for (const child of children) {
+        const desc = child.feature.description?.trim()
+        if (desc)
+          collected.add(desc)
+        if (!visited.has(child.id))
+          stack.push(child.id)
+      }
+    }
+    return [...collected].sort()
   }
 
   /**

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -6,3 +6,6 @@ export type { FetchNodeConfig, FetchOptions, FetchResult, SourceMode } from './f
 
 export { SearchNode } from './search'
 export type { SearchOptions, SearchResult, SearchStrategy } from './search'
+
+export { RPGTree, SYNTHETIC_ROOT_ID } from './tree'
+export type { TreeNode, TreeOptions, TreeResult } from './tree'

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -99,16 +99,18 @@ export class SearchNode {
    * Mirrors Python rapidfuzz fallback when exact/substring search yields nothing.
    */
   private async fuzzyFallbackQuery(terms: string[], scopes?: string[]): Promise<Node[]> {
-    const scope = scopes && scopes.length > 0 ? scopes[0] : undefined
+    const effectiveScopes: (string | undefined)[] = scopes && scopes.length > 0 ? scopes : [undefined]
     const seen = new Map<string, Node>()
     for (const term of terms) {
-      const ids = await suggestNodes(this.rpg, term, { limit: 5, scope })
-      for (const id of ids) {
-        if (seen.has(id))
-          continue
-        const node = await this.rpg.getNode(id)
-        if (node)
-          seen.set(id, node)
+      for (const scope of effectiveScopes) {
+        const ids = await suggestNodes(this.rpg, term, { limit: 5, scope })
+        for (const id of ids) {
+          if (seen.has(id))
+            continue
+          const node = await this.rpg.getNode(id)
+          if (node)
+            seen.set(id, node)
+        }
       }
     }
     return [...seen.values()]

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -1,5 +1,6 @@
 import type { SemanticSearch } from '@pleaseai/soop-encoder/semantic-search'
 import type { Node, RepositoryPlanningGraph } from '@pleaseai/soop-graph'
+import { suggestNodes } from '@pleaseai/soop-graph/fuzzy'
 
 /**
  * Search mode
@@ -29,6 +30,12 @@ export interface SearchOptions {
   lineRange?: [number, number]
   /** Search strategy for feature search (default: hybrid if semanticSearch available, otherwise string) */
   searchStrategy?: SearchStrategy
+  /**
+   * When true, fall back to fuzzy node-suggestion matching if the primary
+   * strategy returns no results. Off by default so existing tests stay
+   * deterministic.
+   */
+  fuzzyFallback?: boolean
 }
 
 /**
@@ -41,6 +48,8 @@ export interface SearchResult {
   totalMatches: number
   /** Search mode used */
   mode: SearchMode
+  /** True if results came from the fuzzy fallback rather than the primary search */
+  fuzzy?: boolean
 }
 
 /**
@@ -66,13 +75,43 @@ export class SearchNode {
    */
   async query(options: SearchOptions): Promise<SearchResult> {
     const results = await this.resolveResults(options)
-    const uniqueNodes = [...new Map(results.map(n => [n.id, n])).values()]
+    let uniqueNodes = [...new Map(results.map(n => [n.id, n])).values()]
+    let fuzzy = false
+
+    if (uniqueNodes.length === 0 && options.fuzzyFallback && options.featureTerms?.length) {
+      const fallback = await this.fuzzyFallbackQuery(options.featureTerms, options.searchScopes)
+      if (fallback.length > 0) {
+        uniqueNodes = fallback
+        fuzzy = true
+      }
+    }
 
     return {
       nodes: uniqueNodes,
       totalMatches: uniqueNodes.length,
       mode: options.mode,
+      ...(fuzzy ? { fuzzy: true } : {}),
     }
+  }
+
+  /**
+   * Fuzzy-match feature terms against every node and return the resulting nodes.
+   * Mirrors Python rapidfuzz fallback when exact/substring search yields nothing.
+   */
+  private async fuzzyFallbackQuery(terms: string[], scopes?: string[]): Promise<Node[]> {
+    const scope = scopes && scopes.length > 0 ? scopes[0] : undefined
+    const seen = new Map<string, Node>()
+    for (const term of terms) {
+      const ids = await suggestNodes(this.rpg, term, { limit: 5, scope })
+      for (const id of ids) {
+        if (seen.has(id))
+          continue
+        const node = await this.rpg.getNode(id)
+        if (node)
+          seen.set(id, node)
+      }
+    }
+    return [...seen.values()]
   }
 
   private async resolveResults(options: SearchOptions): Promise<Node[]> {

--- a/packages/tools/src/tree.ts
+++ b/packages/tools/src/tree.ts
@@ -1,0 +1,212 @@
+import type { EntityType, Node, RepositoryPlanningGraph } from '@pleaseai/soop-graph'
+import { EdgeType, isHighLevelNode } from '@pleaseai/soop-graph'
+import { suggestNodes } from '@pleaseai/soop-graph/fuzzy'
+
+/**
+ * Default max depth for tree listing
+ */
+const DEFAULT_MAX_DEPTH = 2
+
+/**
+ * Synthetic root id used when the graph has multiple top-level nodes
+ */
+export const SYNTHETIC_ROOT_ID = '__root__'
+
+/**
+ * Options for RPGTree.list
+ */
+export interface TreeOptions {
+  /** Start node ID (default: synthetic root containing all top-level nodes) */
+  rootId?: string
+  /** Maximum tree depth to expand (default: 2) */
+  maxDepth?: number
+}
+
+/**
+ * Tree node entry
+ */
+export interface TreeNode {
+  /** Node identifier */
+  id: string
+  /** Display name derived from metadata, directoryPath, or feature description */
+  name: string
+  /** Node type */
+  type: 'high_level' | 'low_level'
+  /** Code entity type for low-level nodes (file, class, function, ...) */
+  entityType?: EntityType
+  /** Source path for low-level nodes */
+  path?: string
+  /** Expanded children (present when within maxDepth) */
+  children?: TreeNode[]
+  /** Number of un-expanded children (present when truncated by depth) */
+  childrenCount?: number
+}
+
+/**
+ * Result of a tree query
+ */
+export interface TreeResult {
+  /** Tree rooted at the requested (or synthetic) root */
+  root: TreeNode | null
+  /** Total nodes in the entire graph */
+  totalNodes: number
+  /** Total nodes in the returned subtree (only when rootId was specified) */
+  subtreeNodes?: number
+  /** Requested rootId that could not be found */
+  notFound?: string
+  /** Suggested similar node IDs when rootId was not found */
+  suggestions?: string[]
+}
+
+/**
+ * RPGTree — feature hierarchy browser
+ *
+ * Mirrors the Python `GraphQueryEngine.list_tree` shape, returning a nested
+ * `{id, name, type, path, children?}` structure with `childrenCount` when
+ * traversal is truncated by maxDepth. Designed as the first call for agents
+ * orienting themselves in an unfamiliar codebase.
+ */
+export class RPGTree {
+  private readonly rpg: RepositoryPlanningGraph
+
+  constructor(rpg: RepositoryPlanningGraph) {
+    this.rpg = rpg
+  }
+
+  /**
+   * List the feature tree starting at rootId (or all top-level nodes).
+   */
+  async list(options: TreeOptions = {}): Promise<TreeResult> {
+    const maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH
+    const allNodes = await this.rpg.getNodes()
+    const totalNodes = allNodes.length
+
+    if (options.rootId) {
+      return this.listFromRoot(options.rootId, maxDepth, totalNodes)
+    }
+
+    return this.listDefaultRoot(maxDepth, totalNodes)
+  }
+
+  private async listFromRoot(rootId: string, maxDepth: number, totalNodes: number): Promise<TreeResult> {
+    const node = await this.rpg.getNode(rootId)
+    if (!node) {
+      const suggestions = await this.suggestRoots(rootId)
+      return { root: null, notFound: rootId, suggestions, totalNodes }
+    }
+
+    const counter = { n: 0 }
+    const tree = await this.buildTree(node, 0, maxDepth, counter)
+    return { root: tree, totalNodes, subtreeNodes: counter.n }
+  }
+
+  private async listDefaultRoot(maxDepth: number, totalNodes: number): Promise<TreeResult> {
+    const topLevel = await this.findTopLevelNodes()
+
+    if (topLevel.length === 1) {
+      const counter = { n: 0 }
+      const tree = await this.buildTree(topLevel[0]!, 0, maxDepth, counter)
+      return { root: tree, totalNodes }
+    }
+
+    // Synthetic root wrapping multiple top-level nodes
+    const counter = { n: 0 }
+    const children: TreeNode[] = []
+    for (const node of topLevel) {
+      children.push(await this.buildTree(node, 1, maxDepth, counter))
+    }
+    const syntheticRoot: TreeNode = {
+      id: SYNTHETIC_ROOT_ID,
+      name: this.rpg.getConfig().name || 'Repository',
+      type: 'high_level',
+      children: children.length > 0 ? children : undefined,
+    }
+    return { root: syntheticRoot, totalNodes }
+  }
+
+  private async buildTree(
+    node: Node,
+    depth: number,
+    maxDepth: number,
+    counter: { n: number },
+  ): Promise<TreeNode> {
+    counter.n += 1
+    const entry: TreeNode = {
+      id: node.id,
+      name: getDisplayName(node),
+      type: node.type,
+    }
+    if (node.metadata?.entityType) {
+      entry.entityType = node.metadata.entityType
+    }
+    if (node.metadata?.path) {
+      entry.path = node.metadata.path
+    }
+    else if (isHighLevelNode(node) && node.directoryPath) {
+      entry.path = node.directoryPath
+    }
+
+    const children = await this.rpg.getChildren(node.id)
+    if (children.length === 0) {
+      return entry
+    }
+
+    if (depth < maxDepth) {
+      const expanded: TreeNode[] = []
+      for (const child of children) {
+        expanded.push(await this.buildTree(child, depth + 1, maxDepth, counter))
+      }
+      entry.children = expanded
+    }
+    else {
+      entry.childrenCount = children.length
+    }
+
+    return entry
+  }
+
+  /**
+   * Find nodes that have no incoming functional edge (graph roots).
+   */
+  private async findTopLevelNodes(): Promise<Node[]> {
+    const all = await this.rpg.getNodes()
+    const roots: Node[] = []
+    for (const node of all) {
+      const incoming = await this.rpg.getInEdges(node.id, EdgeType.Functional)
+      if (incoming.length === 0) {
+        roots.push(node)
+      }
+    }
+    return roots
+  }
+
+  /**
+   * Suggest node IDs similar to the failed root lookup.
+   */
+  private async suggestRoots(query: string): Promise<string[]> {
+    return suggestNodes(this.rpg, query, { limit: 5 })
+  }
+}
+
+/**
+ * Derive a short display name for a node.
+ * Preference order: qualifiedName → directoryPath basename → path basename → feature description.
+ */
+export function getDisplayName(node: Node): string {
+  if (node.metadata?.qualifiedName) {
+    return node.metadata.qualifiedName
+  }
+  if (isHighLevelNode(node) && node.directoryPath) {
+    return basename(node.directoryPath) || node.directoryPath
+  }
+  if (node.metadata?.path) {
+    return basename(node.metadata.path) || node.metadata.path
+  }
+  const desc = node.feature.description
+  return desc.length > 60 ? `${desc.slice(0, 57)}...` : desc
+}
+
+function basename(path: string): string {
+  const parts = path.split('/').filter(Boolean)
+  return parts.at(-1) ?? ''
+}

--- a/packages/tools/src/tree.ts
+++ b/packages/tools/src/tree.ts
@@ -1,4 +1,5 @@
 import type { EntityType, Node, RepositoryPlanningGraph } from '@pleaseai/soop-graph'
+import path from 'node:path'
 import { EdgeType, isHighLevelNode } from '@pleaseai/soop-graph'
 import { suggestNodes } from '@pleaseai/soop-graph/fuzzy'
 
@@ -170,14 +171,10 @@ export class RPGTree {
    */
   private async findTopLevelNodes(): Promise<Node[]> {
     const all = await this.rpg.getNodes()
-    const roots: Node[] = []
-    for (const node of all) {
-      const incoming = await this.rpg.getInEdges(node.id, EdgeType.Functional)
-      if (incoming.length === 0) {
-        roots.push(node)
-      }
-    }
-    return roots
+    const incomingCounts = await Promise.all(
+      all.map(async node => (await this.rpg.getInEdges(node.id, EdgeType.Functional)).length),
+    )
+    return all.filter((_, i) => incomingCounts[i] === 0)
   }
 
   /**
@@ -206,7 +203,8 @@ export function getDisplayName(node: Node): string {
   return desc.length > 60 ? `${desc.slice(0, 57)}...` : desc
 }
 
-function basename(path: string): string {
-  const parts = path.split('/').filter(Boolean)
+function basename(pathStr: string): string {
+  const normalized = pathStr.split(path.sep).join('/')
+  const parts = normalized.split('/').filter(Boolean)
   return parts.at(-1) ?? ''
 }

--- a/packages/tools/tests/tools.test.ts
+++ b/packages/tools/tests/tools.test.ts
@@ -5,7 +5,7 @@ import { MockEmbedding } from '@pleaseai/soop-encoder/embedding'
 import { SemanticSearch } from '@pleaseai/soop-encoder/semantic-search'
 import { RepositoryPlanningGraph } from '@pleaseai/soop-graph'
 import { LocalVectorStore } from '@pleaseai/soop-store/local'
-import { ExploreRPG, FetchNode, SearchNode } from '@pleaseai/soop-tools'
+import { ExploreRPG, FetchNode, RPGTree, SearchNode, SYNTHETIC_ROOT_ID } from '@pleaseai/soop-tools'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 describe('searchNode', () => {
@@ -614,5 +614,323 @@ describe('exploreRPG', () => {
     })
 
     expect(result.nodes).toHaveLength(0)
+  })
+})
+
+describe('rPGTree', () => {
+  let rpg: RepositoryPlanningGraph
+  let tree: RPGTree
+
+  beforeEach(async () => {
+    rpg = await RepositoryPlanningGraph.create({ name: 'test-repo' })
+
+    // Build a small hierarchy:
+    //   root -> moduleA -> funcA1
+    //                  \-> funcA2
+    //         \-> moduleB -> funcB1
+    await rpg.addHighLevelNode({
+      id: 'root',
+      feature: { description: 'application root' },
+      directoryPath: '/src',
+    })
+    await rpg.addHighLevelNode({
+      id: 'moduleA',
+      feature: { description: 'auth module' },
+      directoryPath: '/src/auth',
+    })
+    await rpg.addHighLevelNode({
+      id: 'moduleB',
+      feature: { description: 'data module' },
+      directoryPath: '/src/data',
+    })
+    await rpg.addLowLevelNode({
+      id: 'funcA1',
+      feature: { description: 'login handler' },
+      metadata: { entityType: 'function', path: '/src/auth/login.ts' },
+    })
+    await rpg.addLowLevelNode({
+      id: 'funcA2',
+      feature: { description: 'logout handler' },
+      metadata: { entityType: 'function', path: '/src/auth/logout.ts' },
+    })
+    await rpg.addLowLevelNode({
+      id: 'funcB1',
+      feature: { description: 'data loader' },
+      metadata: { entityType: 'function', path: '/src/data/load.ts' },
+    })
+
+    await rpg.addFunctionalEdge({ source: 'root', target: 'moduleA' })
+    await rpg.addFunctionalEdge({ source: 'root', target: 'moduleB' })
+    await rpg.addFunctionalEdge({ source: 'moduleA', target: 'funcA1' })
+    await rpg.addFunctionalEdge({ source: 'moduleA', target: 'funcA2' })
+    await rpg.addFunctionalEdge({ source: 'moduleB', target: 'funcB1' })
+
+    tree = new RPGTree(rpg)
+  })
+
+  it('returns a nested tree from a specified root', async () => {
+    const result = await tree.list({ rootId: 'root', maxDepth: 2 })
+
+    expect(result.root).not.toBeNull()
+    expect(result.root!.id).toBe('root')
+    expect(result.root!.children).toHaveLength(2)
+    const moduleA = result.root!.children!.find(c => c.id === 'moduleA')
+    expect(moduleA?.children).toHaveLength(2)
+    expect(moduleA?.children?.some(c => c.id === 'funcA1')).toBe(true)
+  })
+
+  it('truncates beyond maxDepth using childrenCount', async () => {
+    const result = await tree.list({ rootId: 'root', maxDepth: 1 })
+
+    expect(result.root!.children).toHaveLength(2)
+    const moduleA = result.root!.children!.find(c => c.id === 'moduleA')
+    expect(moduleA?.children).toBeUndefined()
+    expect(moduleA?.childrenCount).toBe(2)
+  })
+
+  it('uses the unique top-level node as default root', async () => {
+    const result = await tree.list({ maxDepth: 1 })
+
+    // Only 'root' has no incoming functional edge, so it should be the root.
+    expect(result.root!.id).toBe('root')
+  })
+
+  it('falls back to a synthetic root when multiple top-level nodes exist', async () => {
+    // Add another orphan top-level node
+    await rpg.addHighLevelNode({
+      id: 'orphan',
+      feature: { description: 'orphan module' },
+      directoryPath: '/src/orphan',
+    })
+
+    const result = await tree.list({ maxDepth: 1 })
+
+    expect(result.root!.id).toBe(SYNTHETIC_ROOT_ID)
+    const childIds = result.root!.children?.map(c => c.id) ?? []
+    expect(childIds).toContain('root')
+    expect(childIds).toContain('orphan')
+  })
+
+  it('reports subtreeNodes count when rootId is specified', async () => {
+    const result = await tree.list({ rootId: 'moduleA', maxDepth: 5 })
+
+    // moduleA + funcA1 + funcA2 = 3 nodes
+    expect(result.subtreeNodes).toBe(3)
+    expect(result.totalNodes).toBe(6)
+  })
+
+  it('returns suggestions when rootId is unknown', async () => {
+    const result = await tree.list({ rootId: 'modulA', maxDepth: 1 })
+
+    expect(result.root).toBeNull()
+    expect(result.notFound).toBe('modulA')
+    expect(result.suggestions).toBeDefined()
+    // Should suggest 'moduleA' as a close fuzzy match
+    expect(result.suggestions!.length).toBeGreaterThan(0)
+    expect(result.suggestions).toContain('moduleA')
+  })
+
+  it('derives display name from directoryPath basename for high-level nodes', async () => {
+    const result = await tree.list({ rootId: 'moduleA', maxDepth: 0 })
+
+    expect(result.root!.name).toBe('auth')
+  })
+
+  it('derives display name from path basename for low-level nodes', async () => {
+    const result = await tree.list({ rootId: 'funcA1', maxDepth: 0 })
+
+    expect(result.root!.name).toBe('login.ts')
+  })
+
+  it('includes path field for nodes with metadata path or directoryPath', async () => {
+    const result = await tree.list({ rootId: 'moduleA', maxDepth: 1 })
+
+    expect(result.root!.path).toBe('/src/auth')
+    const funcA1 = result.root!.children!.find(c => c.id === 'funcA1')
+    expect(funcA1?.path).toBe('/src/auth/login.ts')
+    expect(funcA1?.entityType).toBe('function')
+  })
+})
+
+describe('fetchNode suggestions and allFeatures', () => {
+  let rpg: RepositoryPlanningGraph
+  let fetch: FetchNode
+
+  beforeEach(async () => {
+    rpg = await RepositoryPlanningGraph.create({ name: 'test-repo' })
+
+    await rpg.addLowLevelNode({
+      id: 'login.ts',
+      feature: { description: 'authentication entry file' },
+      metadata: { entityType: 'file', path: '/src/auth/login.ts' },
+    })
+    await rpg.addLowLevelNode({
+      id: 'login.ts:class:LoginController',
+      feature: { description: 'orchestrate login flow' },
+      metadata: { entityType: 'class', path: '/src/auth/login.ts', startLine: 10, endLine: 50 },
+    })
+    await rpg.addLowLevelNode({
+      id: 'login.ts:function:authenticateUser',
+      feature: { description: 'verify user credentials' },
+      metadata: { entityType: 'function', path: '/src/auth/login.ts', startLine: 60, endLine: 80 },
+    })
+    await rpg.addFunctionalEdge({ source: 'login.ts', target: 'login.ts:class:LoginController' })
+    await rpg.addFunctionalEdge({ source: 'login.ts', target: 'login.ts:function:authenticateUser' })
+
+    fetch = new FetchNode(rpg)
+  })
+
+  it('returns suggestions when ID is mistyped', async () => {
+    const result = await fetch.get({ codeEntities: ['logn.ts'] })
+
+    expect(result.entities).toHaveLength(0)
+    expect(result.notFound).toEqual(['logn.ts'])
+    expect(result.suggestions).toBeDefined()
+    expect(result.suggestions).toContain('login.ts')
+  })
+
+  it('aggregates all_features for a file-type node', async () => {
+    const result = await fetch.get({ codeEntities: ['login.ts'] })
+
+    expect(result.entities).toHaveLength(1)
+    expect(result.entities[0]?.allFeatures).toBeDefined()
+    expect(result.entities[0]?.allFeatures).toContain('orchestrate login flow')
+    expect(result.entities[0]?.allFeatures).toContain('verify user credentials')
+  })
+
+  it('does not set allFeatures for non-file nodes', async () => {
+    const result = await fetch.get({ codeEntities: ['login.ts:class:LoginController'] })
+
+    expect(result.entities).toHaveLength(1)
+    expect(result.entities[0]?.allFeatures).toBeUndefined()
+  })
+
+  it('omits suggestions key when none found', async () => {
+    const result = await fetch.get({ codeEntities: ['totally-unrelated-xyz-999'] })
+
+    expect(result.notFound).toEqual(['totally-unrelated-xyz-999'])
+    expect(result.suggestions).toBeUndefined()
+  })
+})
+
+describe('exploreRPG suggestions and truncation', () => {
+  let rpg: RepositoryPlanningGraph
+  let explore: ExploreRPG
+
+  beforeEach(async () => {
+    rpg = await RepositoryPlanningGraph.create({ name: 'test-repo' })
+
+    await rpg.addHighLevelNode({ id: 'main-module', feature: { description: 'main module' } })
+
+    explore = new ExploreRPG(rpg)
+  })
+
+  it('returns notFound + suggestions for unknown start nodes', async () => {
+    const result = await explore.traverse({
+      startNode: 'man-module', // typo
+      edgeType: 'containment',
+    })
+
+    expect(result.nodes).toHaveLength(0)
+    expect(result.notFound).toBe('man-module')
+    expect(result.suggestions).toBeDefined()
+    expect(result.suggestions).toContain('main-module')
+  })
+
+  it('sets truncated:true when edge cap is exceeded', async () => {
+    // Build a hub with many children, exceeding maxEdges
+    await rpg.addHighLevelNode({ id: 'hub', feature: { description: 'hub' } })
+    for (let i = 0; i < 25; i++) {
+      const childId = `child-${i}`
+      await rpg.addLowLevelNode({
+        id: childId,
+        feature: { description: `child ${i}` },
+        metadata: { entityType: 'function', path: `/src/${childId}.ts` },
+      })
+      await rpg.addFunctionalEdge({ source: 'hub', target: childId })
+    }
+
+    const result = await explore.traverse({
+      startNode: 'hub',
+      edgeType: 'containment',
+      maxDepth: 1,
+    })
+
+    expect(result.edges.length).toBe(20)
+    expect(result.truncated).toBe(true)
+  })
+
+  it('respects an explicit maxEdges override', async () => {
+    await rpg.addHighLevelNode({ id: 'hub', feature: { description: 'hub' } })
+    for (let i = 0; i < 10; i++) {
+      const childId = `child-${i}`
+      await rpg.addLowLevelNode({
+        id: childId,
+        feature: { description: `child ${i}` },
+        metadata: { entityType: 'function', path: `/src/${childId}.ts` },
+      })
+      await rpg.addFunctionalEdge({ source: 'hub', target: childId })
+    }
+
+    const result = await explore.traverse({
+      startNode: 'hub',
+      edgeType: 'containment',
+      maxDepth: 1,
+      maxEdges: 3,
+    })
+
+    expect(result.edges.length).toBe(3)
+    expect(result.truncated).toBe(true)
+  })
+})
+
+describe('searchNode fuzzy fallback', () => {
+  let rpg: RepositoryPlanningGraph
+  let search: SearchNode
+
+  beforeEach(async () => {
+    rpg = await RepositoryPlanningGraph.create({ name: 'test-repo' })
+
+    await rpg.addHighLevelNode({
+      id: 'authentication-module',
+      feature: { description: 'handle user authentication' },
+      directoryPath: '/src/auth',
+    })
+
+    search = new SearchNode(rpg)
+  })
+
+  it('does not fall back when fuzzyFallback is off', async () => {
+    const results = await search.query({
+      mode: 'features',
+      featureTerms: ['authentcation'], // typo
+    })
+
+    // String match misses; fallback disabled by default
+    expect(results.totalMatches).toBe(0)
+    expect(results.fuzzy).toBeUndefined()
+  })
+
+  it('falls back to fuzzy match when no primary results and flag is on', async () => {
+    const results = await search.query({
+      mode: 'features',
+      featureTerms: ['authentcation'], // typo
+      fuzzyFallback: true,
+    })
+
+    expect(results.totalMatches).toBeGreaterThan(0)
+    expect(results.nodes.some(n => n.id === 'authentication-module')).toBe(true)
+    expect(results.fuzzy).toBe(true)
+  })
+
+  it('does not engage fuzzy when primary already found results', async () => {
+    const results = await search.query({
+      mode: 'features',
+      featureTerms: ['authentication'],
+      fuzzyFallback: true,
+    })
+
+    expect(results.totalMatches).toBeGreaterThan(0)
+    expect(results.fuzzy).toBeUndefined()
   })
 })


### PR DESCRIPTION
Closes #298.

Adds the remaining RPG-Kit feature-parity items from `vendor/RPG-ZeroRepo/RPG-Kit/scripts/rpg/graph_query.py` to the TypeScript soop MCP server. Builds on top of the agent-UX work in #296 (graceful startup, `instructions`, telemetry) — note that the `SOOP_SERVER_INSTRUCTIONS` / `SOOP_TOOL_ANNOTATIONS` constants referenced in #298 live in that PR, so wiring `soop_tree` into the instructions text is left for a follow-up once #296 lands.

## Changes

### 1. `soop_tree` MCP tool + `RPGTree` class
- New `RPGTree` in `packages/tools/src/tree.ts` mirroring the Python `list_tree(root_id, max_depth)` shape: nested `{id, name, type, path, children?}` with `childrenCount` when truncated by `maxDepth`.
- Returns the unique top-level node, or a synthetic root containing all top-level nodes when the graph has multiple roots.
- Registered as `soop_tree` MCP tool with `TreeInputSchema` (default `maxDepth: 2`).
- Missing-root responses include `notFound + suggestions` inline.

### 2. Fuzzy-match fallback + suggestion-on-miss
- New `@pleaseai/soop-graph/fuzzy` module: hand-rolled Levenshtein with `scoreCandidate`, `rankNodes`, and `suggestNodes(rpg, query, {limit, scope})`. Scoring tiers (exact > prefix/suffix > substring > fuzzy) mirror Python rapidfuzz so that substring matches always beat Levenshtein.
- `FetchNode.get()` returns aggregated `suggestions` for all `notFound` IDs (deduped, ranked, capped at 5).
- `ExploreRPG.traverse()` no longer throws when `startNode` is missing; it returns `notFound + suggestions` inline. `executeExplore` reflects the new contract.
- `SearchNode` gains an opt-in `fuzzyFallback` flag (gated off by default so existing deterministic tests keep their semantics). When enabled and the primary strategy yields nothing, it falls back to `suggestNodes`-driven matching and sets `fuzzy: true` on the result.

### 3. Minor parity fixes
- `ExploreRPG`: default edge cap of 20 (mirrors Python `_MAX_EXPLORE_EDGES`) with `truncated: true` flag. Override via the new `maxEdges` option / MCP param.
- `FetchNode`: file-type nodes now return `allFeatures` — distinct feature descriptions aggregated from descendant entities (mirrors `graph_query.py:503-510`).

## Acceptance criteria

| Criterion | Status |
|---|---|
| `soop_tree` returns nested feature hierarchy in a single MCP call | ✅ |
| Typo'd `node_id` to `soop_fetch` / `soop_explore` returns up to 5 ranked suggestions instead of empty `notFound` | ✅ |
| `soop_explore` sets `truncated: true` once edge cap is exceeded | ✅ |
| `soop_fetch` on a file node includes `all_features` (camelCased as `allFeatures` for codebase consistency) | ✅ |
| New behavior covered by tests | ✅ — 42 new passing tests (17 fuzzy unit, 10 RPGTree, 4 fetch suggestions/allFeatures, 3 explore suggestions/truncated, 3 search fuzzyFallback, 5 MCP tree integration) |

## Test results

```
Tests: 38 failed | 1178 passed | 1 skipped (1217 total)
```

Failure count matches `main` exactly (verified via `git stash`) — no new regressions. The 38 baseline failures are pre-existing flaky/environment-dependent suites (encoder LLM-mocked retries, husky/wasm-dependent integration paths, evolve outputPath validation).

## Out of scope

- `_normalize_path` / `code_dir` prefix stripping — already noted as not needed for the unified `workspace==repo` layout.
- Existing hybrid/vector/fts strategies remain primary; fuzzy is fallback only.
- `SOOP_SERVER_INSTRUCTIONS` / `SOOP_TOOL_ANNOTATIONS` updates — those constants come from #296 and will be wired in a follow-up once that PR merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `soop_tree` to browse the feature hierarchy and fuzzy suggestions across tools to recover from mistyped node IDs. Brings `Search`, `Fetch`, and `Explore` to RPG‑Kit parity, with cross‑platform path handling and clearer truncation semantics.

- New Features
  - `soop_tree` via `RPGTree`: nested `{id, name, type, path, children?}` with `childrenCount` when depth‑truncated; uses the unique top-level node or a synthetic root; default `maxDepth: 2`; unknown `rootId` returns `notFound` + suggestions.
  - `@pleaseai/soop-graph/fuzzy`: Levenshtein‑based suggestions with ranking (exact > prefix/suffix > substring > fuzzy). Used by `FetchNode`, `ExploreRPG`, and `SearchNode`’s opt‑in `fuzzyFallback`.

- Refactors
  - `ExploreRPG`: default edge cap 20 with `truncated: true`; optional `maxEdges`; stops traversal once cap is hit; missing `startNode` returns `notFound` + `suggestions`.
  - `FetchNode`: file nodes include `allFeatures`; aggregates up to 5 ranked suggestions when IDs are missing.
  - `SearchNode`: `fuzzyFallback` now checks all `searchScopes` when primary search returns nothing.
  - MCP: registers `soop_tree` with `TreeInputSchema`. Tool responses may include `suggestions`, `notFound`, `truncated`, and `fuzzy` flags.
  - Cross‑platform and perf: `tree` and `@pleaseai/soop-graph/fuzzy` use `path.sep`‑safe name derivation; top‑level discovery in `tree` runs in parallel.

<sup>Written for commit 12fb84cd4f6c010a4fc5e09cc176e6881c83f10d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

